### PR TITLE
Make hook installation optional

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -379,67 +379,9 @@ in
           _pre_commit_hooks_nix_config=${configFile}
           _pre_commit_hooks_nix_install_stages='${concatStringsSep " " install_stages}'
 
-          if ! type -t git >/dev/null; then
-            # This happens in pure shells, including lorri
-            echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
-          elif ! $_pre_commit_hooks_nix_git rev-parse --git-dir &> /dev/null; then
-            echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
-          else
-            GIT_WC=`$_pre_commit_hooks_nix_git rev-parse --show-toplevel`
+          source ${../src/pre-commit-install.sh}
 
-            # These update procedures compare before they write, to avoid
-            # filesystem churn. This improves performance with watch tools like lorri
-            # and prevents installation loops by via lorri.
-
-            if readlink "''${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
-              && [[ $(readlink "''${GIT_WC}/.pre-commit-config.yaml") == "$_pre_commit_hooks_nix_config" ]]; then
-              echo 1>&2 "pre-commit-hooks.nix: hooks up to date"
-            else
-              echo 1>&2 "pre-commit-hooks.nix: updating $PWD repo"
-
-              [ -L .pre-commit-config.yaml ] && unlink .pre-commit-config.yaml
-
-              if [ -e "''${GIT_WC}/.pre-commit-config.yaml" ]; then
-                echo 1>&2 "pre-commit-hooks.nix: WARNING: Refusing to install because of pre-existing .pre-commit-config.yaml"
-                echo 1>&2 "    1. Translate .pre-commit-config.yaml contents to the new syntax in your Nix file"
-                echo 1>&2 "        see https://github.com/cachix/pre-commit-hooks.nix#getting-started"
-                echo 1>&2 "    2. remove .pre-commit-config.yaml"
-                echo 1>&2 "    3. add .pre-commit-config.yaml to .gitignore"
-              else
-                ln -fs "$_pre_commit_hooks_nix_config" "''${GIT_WC}/.pre-commit-config.yaml"
-                # Remove any previously installed hooks (since pre-commit itself has no convergent design)
-                hooks="pre-commit pre-merge-commit pre-push prepare-commit-msg commit-msg post-checkout post-commit"
-                for hook in $hooks; do
-                  pre-commit uninstall -t $hook
-                done
-                # Add hooks for configured stages (only) ...
-                if [ ! -z "$_pre_commit_hooks_nix_install_stages" ]; then
-                  for stage in $_pre_commit_hooks_nix_install_stages; do
-                    if [[ "$stage" == "manual" ]]; then
-                      continue
-                    fi
-                    case $stage in
-                      # if you amend these switches please also review $hooks above
-                      commit | merge-commit | push)
-                        stage="pre-"$stage
-                        pre-commit install -t $stage
-                        ;;
-                      prepare-commit-msg | commit-msg | post-checkout | post-commit)
-                        pre-commit install -t $stage
-                        ;;
-                      *)
-                        echo 1>&2 "ERROR: pre-commit-hooks.nix: either $stage is not a valid stage or pre-commit-hooks.nix doesn't yet support it."
-                        exit 1
-                        ;;
-                    esac
-                  done
-                # ... or default 'pre-commit' hook
-                else
-                  pre-commit install
-                fi
-              fi
-            fi
-          fi
+          _pre_commit_hooks_nix_install_main
         '';
     };
 }

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -281,12 +281,22 @@ in
           defaultText = "<derivation>";
         };
 
+      environmentSetupScript =
+        mkOption {
+          type = types.str;
+          description = lib.mdDoc
+            ''
+              A bash snippet that provides functions for updating the config file and installing the hook scripts.
+            '';
+          readOnly = true;
+        };
+
       installationScript =
         mkOption {
           type = types.str;
           description = lib.mdDoc
             ''
-              A bash snippet that installs nix-pre-commit-hooks in the current directory
+              A bash snippet that installs nix-pre-commit-hooks in the current directory.
             '';
           readOnly = true;
         };
@@ -372,7 +382,7 @@ in
           default_stages = cfg.default_stages;
         };
 
-      installationScript =
+      environmentSetupScript =
         ''
           export PATH=${cfg.package}/bin:$PATH
           _pre_commit_hooks_nix_git=${git}/bin/git
@@ -380,6 +390,11 @@ in
           _pre_commit_hooks_nix_install_stages='${concatStringsSep " " install_stages}'
 
           source ${../src/pre-commit-install.sh}
+        '';
+
+      installationScript =
+        ''
+          ${cfg.environmentSetupScript}
 
           _pre_commit_hooks_nix_install_main
         '';

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -22,6 +22,9 @@ let
           src = ../.;
           hooks = {
             shellcheck.enable = true;
+            # `types_or = [ ... something ... ]` doesn't pick up our .sh file
+            shellcheck.types_or = nixpkgs.lib.mkForce [ ];
+
             nixpkgs-fmt.enable = true;
           };
         };

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -9,8 +9,7 @@ _pre_commit_hooks_nix_install_main() {
     # filesystem churn. This improves performance with watch tools like lorri
     # and prevents installation loops by via lorri.
 
-    if readlink "${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
-      && [[ $(readlink "${GIT_WC}/.pre-commit-config.yaml") == "$_pre_commit_hooks_nix_config" ]]; then
+    if _pre_commit_hooks_nix_is_config_up_to_date; then
       echo 1>&2 "pre-commit-hooks.nix: hooks up to date"
     else
       echo 1>&2 "pre-commit-hooks.nix: updating $PWD repo"
@@ -43,6 +42,11 @@ _pre_commit_hooks_nix_find_git_toplevel() {
   else
     $_pre_commit_hooks_nix_git rev-parse --show-toplevel
   fi
+}
+
+_pre_commit_hooks_nix_is_config_up_to_date() {
+  readlink "${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
+      && [[ $(readlink "${GIT_WC}/.pre-commit-config.yaml") == "$_pre_commit_hooks_nix_config" ]]
 }
 
 _pre_commit_hooks_nix_install_stages() {

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -24,7 +24,7 @@ _pre_commit_hooks_nix_find_git_toplevel() {
 
 _pre_commit_hooks_nix_is_config_up_to_date() {
   readlink "${_pre_commit_hooks_nix_local_config_file}" >/dev/null \
-      && [[ $(readlink "${_pre_commit_hooks_nix_local_config_file}") == "$_pre_commit_hooks_nix_config" ]]
+      && [[ "$(readlink "${_pre_commit_hooks_nix_local_config_file}")" == "$_pre_commit_hooks_nix_config" ]]
 }
 
 _pre_commit_hooks_nix_ensure_config_file_up_to_date() {

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -10,15 +10,14 @@
 # Functions marked (private) are not guaranteed to be stable for reasons including:
 #  - dependency on global variables that are not part of the public API
 #  - likely to be changed in the future to improve behavior or implementation details
-if ! ${_pre_commit_hooks_nix_git:?}; then
-  echo 1>&2 "ERROR: pre-commit-hooks.nix: _pre_commit_hooks_nix_git is not set. It must be set before loading pre-commit-install.sh."
-fi
-if ! ${_pre_commit_hooks_nix_config:?}; then
-  echo 1>&2 "ERROR: pre-commit-hooks.nix: _pre_commit_hooks_nix_config is not set. It must be set before loading pre-commit-install.sh."
-fi
-if ! ${_pre_commit_hooks_nix_install_stages:?}; then
-  echo 1>&2 "ERROR: pre-commit-hooks.nix: _pre_commit_hooks_nix_install_stages is not set. It must be set before loading pre-commit-install.sh."
-fi
+# The public API uses the following global variables, which are checked here:
+(
+  : "${_pre_commit_hooks_nix_git:?}"
+  : "${_pre_commit_hooks_nix_config:?}"
+  : "${_pre_commit_hooks_nix_install_stages:?}"
+) || {
+  echo >&2 "ERROR: pre-commit-hooks.nix: missing global variables. Please initialize them in your shellHook."
+}
 
 # (public)
 #

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -4,6 +4,12 @@
 # They are meant to be loaded into interactive shells, so use an underscore prefix
 # to avoid polluting the command tab completion.
 
+# PUBLIC API
+#
+# We make a reasonable effort to keep the functions marked (public) stable.
+# Functions marked (private) are not guaranteed to be stable for reasons including:
+#  - dependency on global variables that are not part of the public API
+#  - likely to be changed in the future to improve behavior or implementation details
 if ! ${_pre_commit_hooks_nix_git:?}; then
   echo 1>&2 "ERROR: pre-commit-hooks.nix: _pre_commit_hooks_nix_git is not set. It must be set before loading pre-commit-install.sh."
 fi
@@ -14,19 +20,27 @@ if ! ${_pre_commit_hooks_nix_install_stages:?}; then
   echo 1>&2 "ERROR: pre-commit-hooks.nix: _pre_commit_hooks_nix_install_stages is not set. It must be set before loading pre-commit-install.sh."
 fi
 
-
+# (public)
+#
+# Install the hooks and the config file.
 _pre_commit_hooks_nix_install_main() {
   if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel "skipping installation.")/.pre-commit-config.yaml"; then
     _pre_commit_hooks_nix_ensure_config_file_up_to_date && _pre_commit_hooks_nix_install_stages
   fi
 }
 
+# (public)
+#
+# Only update the config file.
 _pre_commit_hooks_nix_install_config_file_only() {
   if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel "not updating local config file link.")/.pre-commit-config.yaml"; then
     _pre_commit_hooks_nix_ensure_config_file_up_to_date
   fi
 }
 
+# (private)
+#
+# Find the root of the worktree.
 _pre_commit_hooks_nix_find_git_toplevel() {
   local msg="$1"
   if ! type -t git >/dev/null; then
@@ -41,11 +55,13 @@ _pre_commit_hooks_nix_find_git_toplevel() {
   fi
 }
 
+# (private)
 _pre_commit_hooks_nix_is_config_up_to_date() {
   readlink "${_pre_commit_hooks_nix_local_config_file}" >/dev/null \
       && [[ "$(readlink "${_pre_commit_hooks_nix_local_config_file}")" == "$_pre_commit_hooks_nix_config" ]]
 }
 
+# (private)
 _pre_commit_hooks_nix_ensure_config_file_up_to_date() {
   # These update procedures compare before they write, to avoid
   # filesystem churn. This improves performance with watch tools like lorri
@@ -71,6 +87,9 @@ _pre_commit_hooks_nix_ensure_config_file_up_to_date() {
   ln -fs "$_pre_commit_hooks_nix_config" "${_pre_commit_hooks_nix_local_config_file}"
 }
 
+# (private)
+#
+# Perform the installation of the hooks. Relies on some global variables.
 _pre_commit_hooks_nix_install_stages() {
   # Remove any previously installed hooks (since pre-commit itself has no convergent design)
   hooks="pre-commit pre-merge-commit pre-push prepare-commit-msg commit-msg post-checkout post-commit"

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -1,0 +1,68 @@
+
+# This file provides utilities that are used by the `shellHook` among other things.
+# They are meant to be loaded into interactive shells, so use an underscore prefix
+# to avoid polluting the command tab completion.
+
+_pre_commit_hooks_nix_install_main() {
+  if ! type -t git >/dev/null; then
+    # This happens in pure shells, including lorri
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
+  elif ! $_pre_commit_hooks_nix_git rev-parse --git-dir &> /dev/null; then
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
+  else
+    GIT_WC=`$_pre_commit_hooks_nix_git rev-parse --show-toplevel`
+
+    # These update procedures compare before they write, to avoid
+    # filesystem churn. This improves performance with watch tools like lorri
+    # and prevents installation loops by via lorri.
+
+    if readlink "${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
+      && [[ $(readlink "${GIT_WC}/.pre-commit-config.yaml") == "$_pre_commit_hooks_nix_config" ]]; then
+      echo 1>&2 "pre-commit-hooks.nix: hooks up to date"
+    else
+      echo 1>&2 "pre-commit-hooks.nix: updating $PWD repo"
+
+      [ -L .pre-commit-config.yaml ] && unlink .pre-commit-config.yaml
+
+      if [ -e "${GIT_WC}/.pre-commit-config.yaml" ]; then
+        echo 1>&2 "pre-commit-hooks.nix: WARNING: Refusing to install because of pre-existing .pre-commit-config.yaml"
+        echo 1>&2 "    1. Translate .pre-commit-config.yaml contents to the new syntax in your Nix file"
+        echo 1>&2 "        see https://github.com/cachix/pre-commit-hooks.nix#getting-started"
+        echo 1>&2 "    2. remove .pre-commit-config.yaml"
+        echo 1>&2 "    3. add .pre-commit-config.yaml to .gitignore"
+      else
+        ln -fs "$_pre_commit_hooks_nix_config" "${GIT_WC}/.pre-commit-config.yaml"
+        # Remove any previously installed hooks (since pre-commit itself has no convergent design)
+        hooks="pre-commit pre-merge-commit pre-push prepare-commit-msg commit-msg post-checkout post-commit"
+        for hook in $hooks; do
+          pre-commit uninstall -t $hook
+        done
+        # Add hooks for configured stages (only) ...
+        if [ ! -z "$_pre_commit_hooks_nix_install_stages" ]; then
+          for stage in $_pre_commit_hooks_nix_install_stages; do
+            if [[ "$stage" == "manual" ]]; then
+              continue
+            fi
+            case $stage in
+              # if you amend these switches please also review $hooks above
+              commit | merge-commit | push)
+                stage="pre-"$stage
+                pre-commit install -t $stage
+                ;;
+              prepare-commit-msg | commit-msg | post-checkout | post-commit)
+                pre-commit install -t $stage
+                ;;
+              *)
+                echo 1>&2 "ERROR: pre-commit-hooks.nix: either $stage is not a valid stage or pre-commit-hooks.nix doesn't yet support it."
+                exit 1
+                ;;
+            esac
+          done
+        # ... or default 'pre-commit' hook
+        else
+          pre-commit install
+        fi
+      fi
+    fi
+  fi
+}

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -23,8 +23,8 @@ _pre_commit_hooks_nix_find_git_toplevel() {
 }
 
 _pre_commit_hooks_nix_is_config_up_to_date() {
-  readlink "${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
-      && [[ $(readlink "${GIT_WC}/.pre-commit-config.yaml") == "$_pre_commit_hooks_nix_config" ]]
+  readlink "${_pre_commit_hooks_nix_local_config_file}" >/dev/null \
+      && [[ $(readlink "${_pre_commit_hooks_nix_local_config_file}") == "$_pre_commit_hooks_nix_config" ]]
 }
 
 _pre_commit_hooks_nix_ensure_config_file_up_to_date() {
@@ -40,7 +40,7 @@ _pre_commit_hooks_nix_ensure_config_file_up_to_date() {
 
   [ -L .pre-commit-config.yaml ] && unlink .pre-commit-config.yaml
 
-  if [ -e "${GIT_WC}/.pre-commit-config.yaml" ]; then
+  if [ -e "${_pre_commit_hooks_nix_local_config_file}" ]; then
     echo 1>&2 "pre-commit-hooks.nix: WARNING: Refusing to install because of pre-existing .pre-commit-config.yaml"
     echo 1>&2 "    1. Translate .pre-commit-config.yaml contents to the new syntax in your Nix file"
     echo 1>&2 "        see https://github.com/cachix/pre-commit-hooks.nix#getting-started"
@@ -49,7 +49,7 @@ _pre_commit_hooks_nix_ensure_config_file_up_to_date() {
     return 1;
   fi
 
-  ln -fs "$_pre_commit_hooks_nix_config" "${GIT_WC}/.pre-commit-config.yaml"
+  ln -fs "$_pre_commit_hooks_nix_config" "${_pre_commit_hooks_nix_local_config_file}"
 }
 
 _pre_commit_hooks_nix_install_stages() {

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -4,14 +4,7 @@
 # to avoid polluting the command tab completion.
 
 _pre_commit_hooks_nix_install_main() {
-  if ! type -t git >/dev/null; then
-    # This happens in pure shells, including lorri
-    echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
-  elif ! $_pre_commit_hooks_nix_git rev-parse --git-dir &> /dev/null; then
-    echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
-  else
-    GIT_WC=`$_pre_commit_hooks_nix_git rev-parse --show-toplevel`
-
+  if GIT_WC="$(_pre_commit_hooks_nix_find_git_toplevel)"; then
     # These update procedures compare before they write, to avoid
     # filesystem churn. This improves performance with watch tools like lorri
     # and prevents installation loops by via lorri.
@@ -64,5 +57,18 @@ _pre_commit_hooks_nix_install_main() {
         fi
       fi
     fi
+  fi
+}
+
+_pre_commit_hooks_nix_find_git_toplevel() {
+  if ! type -t git >/dev/null; then
+    # This happens in pure shells, including lorri
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
+    return 1
+  elif ! $_pre_commit_hooks_nix_git rev-parse --git-dir &> /dev/null; then
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
+    return 1
+  else
+    $_pre_commit_hooks_nix_git rev-parse --show-toplevel
   fi
 }

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -4,24 +4,25 @@
 # to avoid polluting the command tab completion.
 
 _pre_commit_hooks_nix_install_main() {
-  if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel)/.pre-commit-config.yaml"; then
+  if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel "skipping installation.")/.pre-commit-config.yaml"; then
     _pre_commit_hooks_nix_ensure_config_file_up_to_date && _pre_commit_hooks_nix_install_stages
   fi
 }
 
 _pre_commit_hooks_nix_install_config_file_only() {
-  if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel)/.pre-commit-config.yaml"; then
+  if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel "not updating local config file link.")/.pre-commit-config.yaml"; then
     _pre_commit_hooks_nix_ensure_config_file_up_to_date
   fi
 }
 
 _pre_commit_hooks_nix_find_git_toplevel() {
+  local msg="$1"
   if ! type -t git >/dev/null; then
     # This happens in pure shells, including lorri
-    echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; $msg"
     return 1
   elif ! $_pre_commit_hooks_nix_git rev-parse --git-dir &> /dev/null; then
-    echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
+    echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; $msg"
     return 1
   else
     $_pre_commit_hooks_nix_git rev-parse --show-toplevel

--- a/src/pre-commit-install.sh
+++ b/src/pre-commit-install.sh
@@ -9,6 +9,12 @@ _pre_commit_hooks_nix_install_main() {
   fi
 }
 
+_pre_commit_hooks_nix_install_config_file_only() {
+  if _pre_commit_hooks_nix_local_config_file="$(_pre_commit_hooks_nix_find_git_toplevel)/.pre-commit-config.yaml"; then
+    _pre_commit_hooks_nix_ensure_config_file_up_to_date
+  fi
+}
+
 _pre_commit_hooks_nix_find_git_toplevel() {
   if ! type -t git >/dev/null; then
     # This happens in pure shells, including lorri


### PR DESCRIPTION
A highly opinionated workflow doesn't work for all projects, especially ones that already have a long history, notably NixOS/nix. Some people hate pre-commit with a passion.

These things should not be showstoppers.

To quote the docs:

## Opting out, opting in

Users can enforce their own preference by setting `NIX_PRE_COMMIT_HOOKS_INSTALL` to `0` or `1` in their environment, e.g. in `.profile` or in [`home.sessionVariables`](https://nix-community.github.io/home-manager/options.html#opt-home.sessionVariables) for home-manager users.

Furthermore, project maintainers can set a default preference via the `installByDefault` option.

Finally, regardless of these settings, you may install the hooks manually by running `nix-pre-commit-hooks-install` in your shell. This does what it says, and the shell hook will detect that the hooks exist and keep them up to date.
