### PR TITLE
feat: support cargo/runtime dependencies

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -67,10 +67,18 @@ in
 
   # PLEASE keep this sorted alphabetically.
   options.settings = {
-    rust.cargoManifestPath = mkOption {
-      type = types.nullOr types.str;
-      description = "Path to Cargo.toml";
-      default = null;
+    rust = {
+      check.cargoDeps = mkOption {
+        type = types.nullOr types.attrs;
+        description = "Cargo dependencies needed to run the checks.";
+        example = "pkgs.rustPlatform.importCargoLock { lockFile = ./Cargo.lock; }";
+        default = null;
+      };
+      cargoManifestPath = mkOption {
+        type = types.nullOr types.str;
+        description = "Path to Cargo.toml";
+        default = null;
+      };
     };
   };
 

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -13,6 +13,8 @@ let
     ;
 
   inherit (pkgs) runCommand;
+  inherit (pkgs.rustPlatform) cargoSetupHook;
+  inherit (pkgs.stdenv) mkDerivation;
 
   cfg = config;
   install_stages = lib.unique (builtins.concatLists (lib.mapAttrsToList (_: h: h.stages) enabledHooks));
@@ -26,6 +28,7 @@ let
     if excludes == [ ] then "^$" else "(${concatStringsSep "|" excludes})";
 
   enabledHooks = filterAttrs (id: value: value.enable) cfg.hooks;
+  enabledExtraPackages = builtins.concatLists (mapAttrsToList (_: value: value.extraPackages) enabledHooks);
   processedHooks =
     mapAttrsToList (id: value: value.raw // { inherit id; }) enabledHooks;
 
@@ -51,34 +54,37 @@ let
     );
 
   run =
-    runCommand "pre-commit-run" { buildInputs = [ cfg.gitPackage ]; } ''
-      set +e
-      HOME=$PWD
-      # Use `chmod +w` instead of `cp --no-preserve=mode` to be able to write and to
-      # preserve the executable bit at the same time
-      cp -R ${cfg.rootSrc} src
-      chmod -R +w src
-      ln -fs ${configFile} src/.pre-commit-config.yaml
-      cd src
-      rm -rf .git
-      git init -q
-      git add .
-      git config --global user.email "you@example.com"
-      git config --global user.name "Your Name"
-      git commit -m "init" -q
-      if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
-      then
-        echo "Running: $ pre-commit run --hook-stage manual --all-files"
-        ${cfg.package}/bin/pre-commit run --hook-stage manual --all-files
-      else
-        echo "Running: $ pre-commit run --all-files"
-        ${cfg.package}/bin/pre-commit run --all-files
-      fi
-      exitcode=$?
-      git --no-pager diff --color
-      mkdir $out
-      [ $? -eq 0 ] && exit $exitcode
-    '';
+    mkDerivation {
+      name = "pre-commit-run";
+
+      src = cfg.rootSrc;
+      buildInputs = [ cfg.gitPackage ];
+      nativeBuildInputs = enabledExtraPackages
+        ++ lib.optional (config.settings.rust.check.cargoDeps != null) cargoSetupHook;
+      cargoDeps = config.settings.rust.check.cargoDeps;
+      buildPhase = ''
+        set +e
+        HOME=$PWD
+        ln -fs ${configFile} .pre-commit-config.yaml
+        git init -q
+        git add .
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+        git commit -m "init" -q
+        if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
+        then
+          echo "Running: $ pre-commit run --hook-stage manual --all-files"
+          ${cfg.package}/bin/pre-commit run --hook-stage manual --all-files
+        else
+          echo "Running: $ pre-commit run --all-files"
+          ${cfg.package}/bin/pre-commit run --all-files
+        fi
+        exitcode=$?
+        git --no-pager diff --color
+        mkdir $out
+        [ $? -eq 0 ] && exit $exitcode
+      '';
+    };
 
   failedAssertions = builtins.map (x: x.message) (builtins.filter (x: !x.assertion) config.assertions);
 


### PR DESCRIPTION
Fixes #126.
Fixes #452.
Fixes #455.

If a Rust project has dependencies, cargo-clippy and cargo check will fail in the pre-commit-check derivation.

This adds a `settings.rust.check.cargoDeps` ~and `settings.runtimeDeps`~ option, which can be used to specify the dependencies, e.g.

```nix
settings = {
  rust.check.cargoDeps = pkgs.rustPlatform.importCargoLock {
    lockFile = ./Cargo.lock;
  };
}
```

and reuses the hooks' `extraPackages` as `nativeBuildInputs` in the derivation, as they are likely to be used in the checks in addition to the devShell environment.