### PR TITLE
Extend `yamllint` hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2528,7 +2528,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
         let
           # .luarc.json has to be in a directory,
           # or lua-language-server will hang forever.
-          luarc = pkgs.writeText ".luarc.json" (builtins.toJSON hooks.lua-ls.settings.config);
+          luarc = pkgs.writeText ".luarc.json" (builtins.toJSON hooks.lua-ls.settings.configuration);
           luarc-dir = pkgs.stdenv.mkDerivation {
             name = "luarc";
             unpackPhase = "true";

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -586,7 +586,7 @@ in
                 "The diagnostic check level";
               default = "Warning";
             };
-            config = mkOption {
+            configuration = mkOption {
               type = types.attrs;
               description = lib.mdDoc
                 "See https://github.com/LuaLS/lua-language-server/wiki/Configuration-File#luarcjson";
@@ -620,7 +620,7 @@ in
         type = types.submodule {
           imports = hookModule;
           options.settings = {
-            config =
+            configuration =
               mkOption {
                 type = types.attrs;
                 description = lib.mdDoc
@@ -1368,7 +1368,7 @@ in
                 default = "auto";
               };
 
-            config =
+            configuration =
               mkOption {
                 type = types.str;
                 description = lib.mdDoc "Multiline-string configuration passed as config file. If set, config set in `typos.settings.configPath` gets ignored.";
@@ -1489,7 +1489,7 @@ in
         type = types.submodule {
           imports = hookModule;
           options.settings = {
-            config =
+            configuration =
               mkOption {
                 type = types.str;
                 description = lib.mdDoc "Multiline-string configuration passed as config file.";
@@ -2955,15 +2955,15 @@ in
           entry =
             let
               # Concatenate config in config file with section for ignoring words generated from list of words to ignore
-              config = "${hooks.typos.settings.config}" + lib.strings.optionalString (hooks.typos.settings.ignored-words != [ ]) "\n\[default.extend-words\]" + lib.strings.concatMapStrings (x: "\n${x} = \"${x}\"") hooks.typos.settings.ignored-words;
-              configFile = builtins.toFile "typos-config.toml" config;
+              configuration = "${hooks.typos.settings.configuration}" + lib.strings.optionalString (hooks.typos.settings.ignored-words != [ ]) "\n\[default.extend-words\]" + lib.strings.concatMapStrings (x: "\n${x} = \"${x}\"") hooks.typos.settings.ignored-words;
+              configFile = builtins.toFile "typos-config.toml" configuration;
               cmdArgs =
                 mkCmdArgs
                   (with hooks.typos.settings; [
                     [ binary "--binary" ]
                     [ (color != "auto") "--color ${color}" ]
-                    [ (config != "") "--config ${configFile}" ]
-                    [ (configPath != "" && config == "") "--config ${configPath}" ]
+                    [ (configuration != "") "--config ${configFile}" ]
+                    [ (configPath != "" && configuration == "") "--config ${configPath}" ]
                     [ diff "--diff" ]
                     [ (exclude != "") "--exclude ${exclude} --force-exclude" ]
                     [ (format != "long") "--format ${format}" ]
@@ -2993,13 +2993,12 @@ in
         package = tools.vale;
         entry =
           let
-            # TODO: was .vale.ini, throwed error in Nix
-            configFile = builtins.toFile "vale.ini" "${hooks.vale.settings.config}";
+            configFile = builtins.toFile ".vale.ini" "${hooks.vale.settings.configuration}";
             cmdArgs =
               mkCmdArgs
                 (with hooks.vale.settings; [
                   [ (configPath != "") " --config ${configPath}" ]
-                  [ (config != "" && configPath == "") " --config ${configFile}" ]
+                  [ (configuration != "" && configPath == "") " --config ${configFile}" ]
                 ]);
           in
           "${hooks.vale.package}/bin/vale${cmdArgs} ${hooks.vale.settings.flags}";


### PR DESCRIPTION
I added a couple of options to the `yamllint` hook, as so far it was only possible to pass a path to the configuration file.
In some comments, I also reasoned why some options weren't added as they do not make sense for a pre-commit hook.

Similar to how I did it for the `typos` hook, there is now also an option to pass a multiline string as configuration to `yamllint`. Additionally `yamllint` allows for a serialized configuration, but the multiline string configuration option is the preferred way. Of course just providing a path to a configuration file remains possible.

The behaviour of the hook itself mostly stayed the same, although the `relaxed` option was removed in favour of a more generalized `preset` option, that allows us to easily add presets, should more ever be added to `yamllint`.

A pre-commit hook only makes sense, if it prevents you from committing if errors were found, so `--strict` should definitely be the default.

### Breaking changes:
- `settings.yamllint.relaxed = true;` is now `settings.yamllint.preset = "relaxed";`
- `settings.yamllint.strict` was added and defaults to `true` :arrow_right: strict error checking for hook

### Additional changes:
For some hooks I recently worked on, I noticed that I was shadowing the top-level attribute `config`, which is never a good idea, so I changed the multiline configuration options to `configuration`.
Affected hooks are `typos` and `vale`. The options were only added recently.