### PR TITLE
typos: allow configPath to be of type string or path + take excludes from `.typos.toml` into account when `pre-commit run typos --all-files` runs

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1476,6 +1476,15 @@ in
                 example = "*.nix";
               };
 
+            force-exclude =
+              mkOption {
+                type = types.bool;
+                description = lib.mdDoc "Respect excluded files from config file even for paths passed explicitly";
+                # This must be true as this is the natural behaviour. Similar to when executing `typos`
+                # from the cmdline.
+                default = true;
+              };
+
             format =
               mkOption {
                 type = types.enum [ "silent" "brief" "long" "json" ];
@@ -3375,7 +3384,8 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
                     # Config file always exists (we generate one if not).
                     [ true "--config ${pathToConfigFile}" ]
                     [ diff "--diff" ]
-                    [ (exclude != "") "--exclude ${exclude} --force-exclude" ]
+                    [ (exclude != "") "--exclude ${exclude}" ]
+                    [ (force-exclude) "--force-exclude" ]
                     [ (format != "long") "--format ${format}" ]
                     [ hidden "--hidden" ]
                     [ (locale != "en") "--locale ${locale}" ]


### PR DESCRIPTION
Unfortunately, the `typos` story still isn't solved properly at this point. My concerns decsribed [here](https://github.com/cachix/pre-commit-hooks.nix/pull/392#issuecomment-1893612669) still exist.

## The Problem

_Hint: The problem is also shortly discussed in the commit messages._

Yes, using `pass_filenames = false` should only be done if no other variant is possible (`pass_filenames = true` is fine). My first "fix" merged a few months ago was wrong. And a commit hook should only run on changed files, I agree.

But, people also use `pre-commit run --all-files` to run all checks on the whole repo. **Some people don't even use Git commit hooks at all and just use pre-commit to run all style checks at once.** And that's a perfeclty valid usecase. 

**The problem is** that if you run `$ pre-commit run typos --all-files`, typos behave differently compared to `$ typos .`.

## The Fix

I modified `typos.configPath` in a way to be either of type string or path. The change is additive and not breaking.

To use the new option, you have to do something like this:

```nix
    settings = {
      typos = {
        # configuration = ""  # POSSIBLE
        # configPath = ".typos.toml"; # OLD
        configPath = .typos.toml; # NEW, RECOMMENDED
      };
    };
```

You can verify that my solution works by checking the typos invocation:

`$ strace -s 64 -Tfe trace=execve pre-commit run --all-files typos`

Unintended files are not longer passed to typos. 🎉 

---

Ping @totoroot @domenkozar 

