### PR TITLE
Fix typos and add pre-commit check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+edn = "edn"             # `cljfmt` option
+mosquitto = "mosquitto" # `typos` example

--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -50,7 +50,7 @@ in
         ''
           An optional package that provides the hook.
 
-          For most hooks, the package name matches the name of the hook and can be overriden directly.
+          For most hooks, the package name matches the name of the hook and can be overridden directly.
 
           ```
           hooks.nixfmt.package = pkgs.nixfmt;

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1450,14 +1450,14 @@ in
             quiet =
               mkOption {
                 type = types.bool;
-                description = lib.mdDoc "Less output per occurence.";
+                description = lib.mdDoc "Less output per occurrence.";
                 default = false;
               };
 
             verbose =
               mkOption {
                 type = types.bool;
-                description = lib.mdDoc "More output per occurence.";
+                description = lib.mdDoc "More output per occurrence.";
                 default = false;
               };
 
@@ -2301,7 +2301,7 @@ in
         };
       lychee = {
         name = "lychee";
-        description = "A fast, async, stream-based link checker that finds broken hyperlinks and mail adresses inside Markdown, HTML, reStructuredText, or any other text file or website.";
+        description = "A fast, async, stream-based link checker that finds broken hyperlinks and mail addresses inside Markdown, HTML, reStructuredText, or any other text file or website.";
         package = tools.lychee;
         entry =
           let
@@ -2925,7 +2925,7 @@ in
         package = tools.vale;
         entry =
           let
-            # TODO: was .vale.ini, throwed error in Nix
+            # TODO: was .vale.ini, threw error in Nix
             configFile = builtins.toFile "vale.ini" "${hooks.vale.settings.config}";
             cmdArgs =
               mkCmdArgs

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,7 @@ let
           hooks = {
             shellcheck.enable = true;
             nixpkgs-fmt.enable = true;
+            typos.enable = true;
           };
         };
         all-tools-eval =


### PR DESCRIPTION
Fix a few typos and add `typos` pre-commit check to `pre-commit-hooks.nix` itself.