### PR TITLE
Silence git noise 

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -68,7 +68,7 @@ let
       git add .
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
-      git commit -m "init"
+      git commit -m "init" -q
       if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
       then
         echo "Running: $ pre-commit run --hook-stage manual --all-files"

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -64,7 +64,7 @@ let
       ln -fs ${configFile} src/.pre-commit-config.yaml
       cd src
       rm -rf .git
-      git init
+      git init -q
       git add .
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"


### PR DESCRIPTION
This change removes unnecessary noise generated by the various git
commands:

```
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint:   git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint:   git branch -m <name>
Initialized empty Git repository in /build/src/.git/
[master (root-commit) a363169] init
 29 files changed, 1143 insertions(+)
[...]
```
