### PR TITLE
Set the default hook package to null

### DIFF
--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -46,6 +46,7 @@ in
 
     package = mkOption {
       type = types.nullOr types.package;
+      default = null;
       description = lib.mdDoc
         ''
           An optional package that provides the hook.

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -138,7 +138,7 @@ in
             Useful for including into the developer environment.
           '';
 
-        default = builtins.map (hook: hook.package) (lib.filter (hook: hook.enable) (builtins.attrValues config.hooks));
+        default = builtins.map (hook: hook.package) (lib.filter (hook: hook.enable && hook.package != null) (builtins.attrValues config.hooks));
       };
 
       hooks =


### PR DESCRIPTION
Allows creating hooks that don't depend on a package, without explicitly setting `package = null;`.
Also fixes the evaluation of `enabledPackages` when a hook doesn't have a package.

Fixes #427.