### PR TITLE
Add `extraPackages` to each hook and propagate them to `enabledPackages`

### DIFF
--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -78,6 +78,18 @@ in
         '';
     };
 
+    extraPackages = mkOption {
+      type = types.listOf types.package;
+      default = [ ];
+      description = lib.mdDoc
+        ''
+          Additional packages required to run the hook.
+
+          These are propagated to `enabledPackages` for constructing developer
+          environments.
+        '';
+    };
+
     entry = mkOption {
       type = types.str;
       description = lib.mdDoc

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -171,36 +171,42 @@ in
       };
       clippy = mkOption {
         description = lib.mdDoc "clippy hook";
-        type = types.submodule {
-          imports = [ hookModule ];
-          options.packageOverrides = {
-            cargo = mkOption {
-              type = types.package;
-              description = lib.mdDoc "The cargo package to use";
+        type = types.submodule
+          ({ config, ... }: {
+            imports = [ hookModule ];
+            options.packageOverrides = {
+              cargo = mkOption {
+                type = types.package;
+                description = lib.mdDoc "The cargo package to use";
+              };
+              clippy = mkOption {
+                type = types.package;
+                description = lib.mdDoc "The clippy package to use";
+              };
             };
-            clippy = mkOption {
-              type = types.package;
-              description = lib.mdDoc "The clippy package to use";
+            options.settings = {
+              denyWarnings = mkOption {
+                type = types.bool;
+                description = lib.mdDoc "Fail when warnings are present";
+                default = false;
+              };
+              offline = mkOption {
+                type = types.bool;
+                description = lib.mdDoc "Run clippy offline";
+                default = true;
+              };
+              allFeatures = mkOption {
+                type = types.bool;
+                description = lib.mdDoc "Run clippy with --all-features";
+                default = false;
+              };
             };
-          };
-          options.settings = {
-            denyWarnings = mkOption {
-              type = types.bool;
-              description = lib.mdDoc "Fail when warnings are present";
-              default = false;
-            };
-            offline = mkOption {
-              type = types.bool;
-              description = lib.mdDoc "Run clippy offline";
-              default = true;
-            };
-            allFeatures = mkOption {
-              type = types.bool;
-              description = lib.mdDoc "Run clippy with --all-features";
-              default = false;
-            };
-          };
-        };
+
+            config.extraPackages = [
+              config.settings.packageOverrides.cargo
+              config.settings.packageOverrides.clippy
+            ];
+          });
       };
       cmake-format = mkOption {
         description = lib.mdDoc "cmake-format hook";
@@ -333,24 +339,27 @@ in
       };
       dune-fmt = mkOption {
         description = lib.mdDoc "dune-fmt hook";
-        type = types.submodule {
-          imports = [ hookModule ];
-          options.settings = {
-            auto-promote =
-              mkOption {
-                type = types.bool;
-                description = lib.mdDoc "Whether to auto-promote the changes.";
-                default = true;
-              };
+        type = types.submodule
+          ({ config, ... }: {
+            imports = [ hookModule ];
+            options.settings = {
+              auto-promote =
+                mkOption {
+                  type = types.bool;
+                  description = lib.mdDoc "Whether to auto-promote the changes.";
+                  default = true;
+                };
 
-            extraRuntimeInputs =
-              mkOption {
-                type = types.listOf types.package;
-                description = lib.mdDoc "Extra runtimeInputs to add to the environment, eg. `ocamlformat`.";
-                default = [ ];
-              };
-          };
-        };
+              extraRuntimeInputs =
+                mkOption {
+                  type = types.listOf types.package;
+                  description = lib.mdDoc "Extra runtimeInputs to add to the environment, eg. `ocamlformat`.";
+                  default = [ ];
+                };
+            };
+
+            config.extraPackages = config.settings.extraRuntimeInputs;
+          });
       };
       eclint = mkOption {
         description = lib.mdDoc "eclint hook";
@@ -1324,19 +1333,25 @@ in
           hooks.rustfmt.packageOverrides.rustfmt = pkgs.rustfmt;
           ```
         '';
-        type = types.submodule {
-          imports = [ hookModule ];
-          options.packageOverrides = {
-            cargo = mkOption {
-              type = types.package;
-              description = lib.mdDoc "The cargo package to use.";
+        type = types.submodule
+          ({ config, ... }: {
+            imports = [ hookModule ];
+            options.packageOverrides = {
+              cargo = mkOption {
+                type = types.package;
+                description = lib.mdDoc "The cargo package to use.";
+              };
+              rustfmt = mkOption {
+                type = types.package;
+                description = lib.mdDoc "The rustfmt package to use.";
+              };
             };
-            rustfmt = mkOption {
-              type = types.package;
-              description = lib.mdDoc "The rustfmt package to use.";
-            };
-          };
-        };
+
+            config.extraPackages = [
+              config.settings.packageOverrides.cargo
+              config.settings.packageOverrides.rustfmt
+            ];
+          });
       };
       statix = mkOption {
         description = lib.mdDoc "statix hook";

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -203,8 +203,8 @@ in
             };
 
             config.extraPackages = [
-              config.settings.packageOverrides.cargo
-              config.settings.packageOverrides.clippy
+              config.packageOverrides.cargo
+              config.packageOverrides.clippy
             ];
           });
       };
@@ -1348,8 +1348,8 @@ in
             };
 
             config.extraPackages = [
-              config.settings.packageOverrides.cargo
-              config.settings.packageOverrides.rustfmt
+              config.packageOverrides.cargo
+              config.packageOverrides.rustfmt
             ];
           });
       };

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1399,22 +1399,26 @@ in
           hooks.treefmt.packageOverrides.treefmt = pkgs.treefmt;
           ```
         '';
-        type = types.submodule {
-          imports = [ hookModule ];
-          options.packageOverrides = {
-            treefmt = mkOption {
-              type = types.package;
-              description = lib.mdDoc "The treefmt package to use";
-            };
-          };
-          options.settings = {
-            formatters = mkOption {
-              type = types.listOf types.package;
-              description = lib.mdDoc "The formatter packages configured by treefmt";
-              default = [ ];
-            };
-          };
-        };
+        type = types.submodule
+          ({ config, ... }:
+            {
+              imports = [ hookModule ];
+              options.packageOverrides = {
+                treefmt = mkOption {
+                  type = types.package;
+                  description = lib.mdDoc "The treefmt package to use";
+                };
+              };
+              options.settings = {
+                formatters = mkOption {
+                  type = types.listOf types.package;
+                  description = lib.mdDoc "The formatter packages configured by treefmt";
+                  default = [ ];
+                };
+              };
+
+              config.extraPackages = config.settings.formatters;
+            });
       };
       typos = mkOption {
         description = lib.mdDoc "typos hook";

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -138,7 +138,14 @@ in
             Useful for including into the developer environment.
           '';
 
-        default = builtins.map (hook: hook.package) (lib.filter (hook: hook.enable && hook.package != null) (builtins.attrValues config.hooks));
+        default = lib.pipe config.hooks [
+          builtins.attrValues
+          (lib.filter (hook: hook.enable))
+          (builtins.concatMap (hook:
+            (lib.optional (hook.package != null) hook.package)
+            ++ hook.extraPackages
+          ))
+        ];
       };
 
       hooks =


### PR DESCRIPTION
`enabledPackages` can be used to include all the relevant packages for enabled hooks into a developer environment. Unfortunately, it doesn't automatically pick up on packages other than a hook's default `package` attribute. By adding an `extraPackages` option to each hook, these other packages can be seamlessly added to developer environments.

I've included defaults for `extraPackages` for the following hooks:

- `treefmt`: the enabled `settings.formatters`
- `clippy`, `rustfmt`: the `packageOverrides`
- `dune-fmt`: the enabled `settings.extraRuntimeInputs`