### PR TITLE
fix(alejandra): one `--exclude` flag per file

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1659,7 +1659,7 @@ in
               cmdArgs =
                 mkCmdArgs (with hooks.alejandra.settings; [
                   [ check "--check" ]
-                  [ (exclude != [ ]) "--exclude ${lib.escapeShellArgs (lib.unique exclude)}" ]
+                  [ (exclude != [ ]) "${lib.escapeShellArgs (map (file: "--exclude '${file}'") (lib.unique exclude))}" ]
                   [ (verbosity == "quiet") "-q" ]
                   [ (verbosity == "silent") "-qq" ]
                   [ (threads != null) "--threads ${toString threads}" ]


### PR DESCRIPTION
`alejandra --exclude file1 file2 file3` doesn't work.

It should be `alejandra --exclude file1 --exclude file2 --exclude file3 `