### PR TITLE
Fix and document lacheck hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ clang-format supports.
 ### LaTeX
 
 - [chktex](https://www.nongnu.org/chktex/)
+- [lacheck](https://ctan.org/pkg/lacheck)
 - [latexindent](https://github.com/cmhughes/latexindent.pl)
 
 ### Lua

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2583,12 +2583,19 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           entry = "${hooks.latexindent.package}/bin/latexindent ${hooks.latexindent.settings.flags}";
         };
       lacheck =
+        let
+          script = pkgs.writeShellScript "precommit-mdsh" ''
+            for file in $(echo "$@"); do
+                "${hooks.lacheck.package}/bin/lacheck" "$file"
+            done
+          '';
+        in
         {
           name = "lacheck";
           description = "A consistency checker for LaTeX documents.";
           types = [ "file" "tex" ];
           package = tools.lacheck;
-          entry = "${hooks.lacheck.package}/bin/lacheck";
+          entry = "${script}";
         };
       lua-ls =
         let


### PR DESCRIPTION
`lacheck` can only run on one file at a time, this PR fixes the hook to do exactly that.
It also adds the hook to the LaTeX section in the readme.