### PR TITLE
Add support for TruffleHog

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3496,6 +3496,23 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           package = tools.pre-commit-hooks;
           entry = "${hooks.trim-trailing-whitespace.package}/bin/trailing-whitespace-fixer";
         };
+      trufflehog =
+        {
+          name = "trufflehog";
+          description = "Secrets scanner";
+          entry =
+            let
+              script = pkgs.writeShellScript "precommit-trufflehog" ''
+                set -e
+                ${hooks.trufflehog.package}/bin/trufflehog --no-update git "file://$(git rev-parse --show-top-level)" --since-commit HEAD --only-verified --fail
+              '';
+            in
+            builtins.toString script;
+          package = pkgs.trufflehog;
+
+          # trufflehog expects to run across the whole repo, not particular files
+          pass_filenames = false;
+        };
       typos =
         {
           name = "typos";

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3462,15 +3462,6 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               );
           files = "(\\.json$)|(\\.toml$)|(\\.mli?$)";
         };
-      trim-trailing-whitespace =
-        {
-          name = "trim-trailing-whitespace";
-          description = "Trim trailing whitespace.";
-          types = [ "text" ];
-          stages = [ "commit" "push" "manual" ];
-          package = tools.pre-commit-hooks;
-          entry = "${hooks.trim-trailing-whitespace.package}/bin/trailing-whitespace-fixer";
-        };
       treefmt =
         let
           inherit (hooks.treefmt) packageOverrides settings;
@@ -3495,6 +3486,15 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           package = wrapper;
           packageOverrides = { treefmt = tools.treefmt; };
           entry = "${hooks.treefmt.package}/bin/treefmt --fail-on-change";
+        };
+      trim-trailing-whitespace =
+        {
+          name = "trim-trailing-whitespace";
+          description = "Trim trailing whitespace.";
+          types = [ "text" ];
+          stages = [ "commit" "push" "manual" ];
+          package = tools.pre-commit-hooks;
+          entry = "${hooks.trim-trailing-whitespace.package}/bin/trailing-whitespace-fixer";
         };
       typos =
         {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3508,7 +3508,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               '';
             in
             builtins.toString script;
-          package = pkgs.trufflehog;
+          package = tools.trufflehog;
 
           # trufflehog expects to run across the whole repo, not particular files
           pass_filenames = false;

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -74,6 +74,7 @@
 , texlive
 , topiary ? null ## Added in nixpkgs on Dec 2, 2022
 , treefmt
+, trufflehog
 , typos
 , typstfmt
 , typstyle ? null ## Add in nixpkgs added on commit 800ca60
@@ -152,6 +153,7 @@ in
     taplo
     topiary
     treefmt
+    trufflehog
     typos
     typstfmt
     typstyle


### PR DESCRIPTION
This adds support for the [TruffleHog](https://github.com/trufflesecurity/trufflehog) secrets scanner. It's presently not nearly as configurable as I'd like, or as neat as I'd like, but hopefully I can take it out of WIP status soon. :)