### PR TITLE
Drop `flake-utils` dependency

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,24 +16,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -89,25 +71,9 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs",
         "nixpkgs-stable": "nixpkgs-stable"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },


### PR DESCRIPTION
I wanted to run `nix flake checks` but it was going to download packages for hours on my 3G-tethered connection … where 2 `nixpkgs` was enough data usage & all these dependencies really start to add up (hence opening the initial issue).

Partially addresses #445

Wasn’t entirely sure how to go about the `README`. After some thought today, I’m not convinced its good to recommend ‘looping’ in examples as folks might be accidentally supporting platforms they or their tools can’t & `nix flake init` just hardcodes the current system to keep everything simple. I went this route with `${system}` as a variable as the block can still be copied into someone’s `(system: …)` ‘loop’, but not married to the idea.

Additionally, removed the unused C compiler from the devShell.