### PR TITLE
Fixed check for manual stage

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -67,7 +67,7 @@ let
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
       git commit -m "init" -q
-      if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
+      if [[ ${toString (compare install_stages [ "manual" ])} -eq 1 ]]
       then
         echo "Running: $ pre-commit run --hook-stage manual --all-files"
         ${cfg.package}/bin/pre-commit run --hook-stage manual --all-files


### PR DESCRIPTION
I've noticed in our setup:
* Checks configured with `default_stages = [ "manual" "pre-push" ];` or `default_stages = ["manual" "push"];` as in the README
* Push-Hook works
* `nix flake check` does not run anything

I think there was a mistake in the detection if the manual stage should be used.