### PR TITLE
feat: add yamlfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ clang-format supports.
 
 - [check-yaml](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_yaml.py)
 - [sort-simple-yaml](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/sort_simple_yaml.py)
+- [yamlfmt](https://github.com/google/yamlfmt)
 - [yamllint](https://github.com/adrienverge/yamllint)
 
 ### TOML

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -72,6 +72,7 @@
 , typos
 , typstfmt
 , zprint
+, yamlfmt
 , yamllint
 , go
 , go-tools
@@ -146,6 +147,7 @@ in
     typos
     typstfmt
     vale
+    yamlfmt
     yamllint
     zprint
     ;


### PR DESCRIPTION
This adds [yamlfmt](https://github.com/google/yamlfmt) with a minimal configuration option for specifying a [config file](https://github.com/google/yamlfmt/blob/main/docs/config-file.md#config-file-discovery).

As https://github.com/cachix/git-hooks.nix always has an ignored `.pre-commit-config.yaml` in the repository, the smallest possible configuration file is usually:

`.yamlfmt`:
```yaml
gitignore_excludes: true
```
which tells the hook to ignore it's own precommit config.

closes #341  // cc @bryanhonof @domenkozar 