### PR TITLE
fix: pyright has moved out of nodePackages

### DIFF
--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -53,6 +53,7 @@
 , poetry
 , pre-commit-hook-ensure-sops ? null
 , python3Packages
+, pyright ? nodePackages.pyright
 , php82Packages
 , ripsecrets ? null
 , ruff ? null
@@ -131,6 +132,7 @@ in
     ormolu
     pre-commit-hook-ensure-sops
     poetry
+    pyright
     revive
     ripsecrets
     ruff
@@ -155,7 +157,7 @@ in
   # TODO: these two should be statically compiled
   inherit (haskellPackages) fourmolu;
   inherit (luaPackages) luacheck;
-  inherit (nodePackages) eslint markdownlint-cli prettier pyright cspell;
+  inherit (nodePackages) eslint markdownlint-cli prettier cspell;
   inherit (ocamlPackages) ocp-indent;
   inherit (python3Packages) autoflake black flake8 flynt isort mkdocs-linkcheck mypy pre-commit-hooks pylint pyupgrade;
   inherit (php82Packages) php-cs-fixer psalm;


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/302680. This makes it possible to use `inputs.nixpkgs.follows` in downstream flakes.