### PR TITLE
Update nixpkgs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,9 @@
+[default]
+extend-ignore-re = [
+  # Ignore `files = "";` declarations
+  "(?Rm)^\\s*files\\s*=.*;$"
+]
+
 [default.extend-words]
 edn = "edn"             # `cljfmt` option
 mosquitto = "mosquitto" # `typos` example

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710765496,
-        "narHash": "sha256-p7ryWEeQfMwTB6E0wIUd5V2cFTgq+DRRBz2hYGnJZyA=",
+        "lastModified": 1718606988,
+        "narHash": "sha256-pmjP5ePc1jz+Okona3HxD7AYT0wbrCwm9bXAlj08nDM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e367f7a1fb93137af22a3908f00b9a35e2d286a7",
+        "rev": "38d3352a65ac9d621b0cd3074d3bef27199ff78f",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1718447546,
+        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "842253bf992c3a7157b67600c2857193f126563a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/e367f7a1fb93137af22a3908f00b9a35e2d286a7?narHash=sha256-p7ryWEeQfMwTB6E0wIUd5V2cFTgq%2BDRRBz2hYGnJZyA%3D' (2024-03-18)
  → 'github:NixOS/nixpkgs/38d3352a65ac9d621b0cd3074d3bef27199ff78f?narHash=sha256-pmjP5ePc1jz%2BOkona3HxD7AYT0wbrCwm9bXAlj08nDM%3D' (2024-06-17)
• Updated input 'nixpkgs-stable':
    'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3?narHash=sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84%3D' (2024-03-17)
  → 'github:NixOS/nixpkgs/842253bf992c3a7157b67600c2857193f126563a?narHash=sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM%3D' (2024-06-15)