### PR TITLE
Fix typstyle argument

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3445,7 +3445,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           lib.throwIf
             (hooks.typstyle.package == null)
             "The version of nixpkgs used by pre-commit-hooks.nix must contain typstyle"
-            "${hooks.typstyle.package}/bin/typstyle";
+            "${hooks.typstyle.package}/bin/typstyle -i";
         files = "\\.typ$";
       };
       vale = {


### PR DESCRIPTION
Hello,

I have added the hook for typstyle, but the entry was missing the `-i`.

This PR should fix it, I have tested it against a typst project of mine with `--override-inputs` this time.
Sorry for the overlook last time !
