### PR TITLE
docs: clarify terraform-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ clang-format supports.
 
 ### Terraform
 
-- `terraform-format`: built-in formatter
+- `terraform-format`: built-in formatter (using [OpenTofu](https://opentofu.org/)'s [`fmt`](https://opentofu.org/docs/cli/commands/fmt/))
 - [tflint](https://github.com/terraform-linters/tflint)
 
 ### YAML


### PR DESCRIPTION
Adds a hint to the documentation that the built-in `terraform-format` hook uses OpenTofu under the hood.