### PR TITLE
feat: add cabal-gild

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Seamless integration of https://pre-commit.com git hooks with Nix.";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.11";
+  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.05";
   inputs.flake-compat = {
     url = "github:edolstra/flake-compat";
     flake = false;

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1813,6 +1813,22 @@ in
           entry = "${hooks.cabal-fmt.package}/bin/cabal-fmt --inplace";
           files = "\\.cabal$";
         };
+      cabal-gild =
+        {
+          name = "cabal-gild";
+          description = "Format Cabal files";
+          package = tools.cabal-gild;
+          entry =
+            let
+              script = pkgs.writeShellScript "precommit-cabal-gild" ''
+                for file in "$@"; do
+                    ${hooks.cabal-gild.package}/bin/cabal-gild --io="$file"
+                done
+              '';
+            in
+            builtins.toString script;
+          files = "\\.cabal$";
+        };
       cabal2nix =
         {
           name = "cabal2nix";

--- a/nix/call-tools.nix
+++ b/nix/call-tools.nix
@@ -2,5 +2,6 @@ pkgs:
 pkgs.lib.flip builtins.removeAttrs [ "override" "overrideDerivation" ]
   (pkgs.callPackage ./tools.nix {
     cabal-fmt = (pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.cabal-fmt).bin;
+    cabal-gild = (pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.cabal-gild).bin;
     hindent = pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.hindent;
   })

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -6,6 +6,7 @@
 , ansible-lint
 , biome
 , cabal-fmt
+, cabal-gild
 , cabal2nix
 , callPackage
 , cargo
@@ -99,6 +100,7 @@ in
     biome
     cabal2nix
     cabal-fmt
+    cabal-gild
     cargo
     clang-tools
     clippy


### PR DESCRIPTION
A(nother) `.cabal` file formatter:

 - https://github.com/tfausak/cabal-gild
 - https://taylor.fausak.me/2024/02/17/gild/

The `nixpkgs-stable` bump isn't strictly necessary, but it seems cleaner compared to writing ad-hoc code to handle the absence of cabal-gild in 23.11.