### PR TITLE
Allow importing modules into the inner module system.

### DIFF
--- a/nix/run.nix
+++ b/nix/run.nix
@@ -6,6 +6,7 @@ builtinStuff@{ pkgs, tools, isFlakes, pre-commit, git, runCommand, writeText, wr
 , excludes ? [ ]
 , tools ? { }
 , default_stages ? [ "commit" ]
+, imports ? [ ]
 }:
 let
   project =
@@ -27,7 +28,7 @@ let
                 rootSrc = gitignore-nix-src.lib.gitignoreSource src;
               });
           }
-        ];
+        ] ++ imports;
     };
   inherit (project.config) installationScript;
 


### PR DESCRIPTION
This simple PR allows to introduce custom hook modules, which are too specific (or broken) for upstream inclusion. It does make consuming code a bit cleaner.