### PR TITLE
Feat/ruff format

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ clang-format supports.
 - [poetry](https://python-poetry.org/docs/pre-commit-hooks)
 - [pyupgrade](https://github.com/asottile/pyupgrade)
 - [ruff](https://github.com/charliermarsh/ruff)
+- [ruff-format](https://github.com/charliermarsh/ruff)
 - [sort-requirements-txt](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/requirements_txt_fixer.py)
 
 ### PHP

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3185,6 +3185,14 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           entry = "${hooks.ruff.package}/bin/ruff check --fix";
           types = [ "python" ];
         };
+      ruff-format =
+        {
+          name = "ruff";
+          description = "An extremely fast Python code formatter, written in Rust.";
+          package = tools.ruff;
+          entry = "${hooks.ruff.package}/bin/ruff format";
+          types = [ "python" ];
+        };
       rustfmt =
         let
           inherit (hooks.rustfmt) packageOverrides;


### PR DESCRIPTION
Thanks for the good work guys, really appreciate it

Since ruff has actually two [pre-commit hooks](https://github.com/astral-sh/ruff-pre-commit), one for linting and one for formatting, I've added the format hook.