### PR TITLE
fix: change ruff format hook name

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3187,7 +3187,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
         };
       ruff-format =
         {
-          name = "ruff";
+          name = "ruff-format";
           description = "An extremely fast Python code formatter, written in Rust.";
           package = tools.ruff;
           entry = "${hooks.ruff.package}/bin/ruff format";


### PR DESCRIPTION
Im my last pull request adding ruff-format, I forgot to change the name of the hook. (Sorry) 
Just fixing that now