### PR TITLE
feat: add `args` and `exclude_types` to hooks

### DIFF
--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -120,9 +120,9 @@ in
 
     exclude_types = mkOption {
       type = types.listOf types.str;
-      description = lib.mdDoc
+      description =
         ''
-          List of file types to exclude. See [Filtering files with types](https://pre-commit.com/#plugins).
+          List of file types to exclude. See [Filtering files with types](https://pre-commit.com/#filtering-files-with-types).
         '';
       default = [ ];
     };
@@ -178,9 +178,10 @@ in
 
     args = mkOption {
       type = types.listOf types.str;
-      description = lib.mdDoc ''
-        List of additional parameters to pass to the hook.
-      '';
+      description =
+        ''
+          List of additional parameters to pass to the hook.
+        '';
       default = [ ];
     };
   };

--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -118,6 +118,15 @@ in
       default = [ ];
     };
 
+    exclude_types = mkOption {
+      type = types.listOf types.str;
+      description = lib.mdDoc
+        ''
+          List of file types to exclude. See [Filtering files with types](https://pre-commit.com/#plugins).
+        '';
+      default = [ ];
+    };
+
     pass_filenames = mkOption {
       type = types.bool;
       description = ''
@@ -166,12 +175,20 @@ in
         if true this hook will run even if there are no matching files.
       '';
     };
+
+    args = mkOption {
+      type = types.listOf types.str;
+      description = lib.mdDoc ''
+        List of additional parameters to pass to the hook.
+      '';
+      default = [ ];
+    };
   };
 
   config = {
     raw =
       {
-        inherit (config) name entry language files types types_or pass_filenames fail_fast require_serial stages verbose always_run;
+        inherit (config) name entry language files types types_or exclude_types pass_filenames fail_fast require_serial stages verbose always_run args;
         id = config.name;
         exclude = mergeExcludes config.excludes;
       };

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3229,7 +3229,8 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           description = "Format shell files.";
           types = [ "shell" ];
           package = tools.shfmt;
-          entry = "${hooks.shfmt.package}/bin/shfmt -w -s -l";
+          entry = "${hooks.shfmt.package}/bin/shfmt -w -l";
+          args = [ "-s" ];
         };
       single-quoted-strings =
         {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3229,8 +3229,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           description = "Format shell files.";
           types = [ "shell" ];
           package = tools.shfmt;
-          entry = "${hooks.shfmt.package}/bin/shfmt -w -l";
-          args = [ "-s" ];
+          entry = "${hooks.shfmt.package}/bin/shfmt -w -s -l";
         };
       single-quoted-strings =
         {


### PR DESCRIPTION
Adds `args` —  a list of additional parameters to pass to the hook.
Adds `exclude_types` —  list of file types to exclude.

Cherry-picked from #414.