### PR TITLE
fix: switch `nixfmt` to `nixfmt-classic`

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2861,7 +2861,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
         {
           name = "nixfmt";
           description = "Nix code prettifier.";
-          package = tools.nixfmt;
+          package = tools.nixfmt-classic;
           entry = "${hooks.nixfmt.package}/bin/nixfmt ${lib.optionalString (hooks.nixfmt.settings.width != null) "--width=${toString hooks.nixfmt.settings.width}"}";
           files = "\\.nix$";
         };

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -45,6 +45,8 @@
 , mdsh
 , nil
 , nixfmt
+, nixfmt-classic ? null
+, nixfmt-rfc-style ? null
 , nixpkgs-fmt
 , nodePackages
 , ocamlPackages
@@ -131,7 +133,6 @@ in
     mdl
     mdsh
     nil
-    nixfmt
     nixpkgs-fmt
     ormolu
     pre-commit-hook-ensure-sops
@@ -201,4 +202,9 @@ in
   checkmake = if stdenv.isLinux || checkmake.version >= "0.2.2" then checkmake else null;
 
   headache = callPackage ./headache { };
+
+  # nixfmt was renamed to nixfmt-classic in 24.05.
+  # nixfmt may be replaced by nixfmt-rfc-style in the future.
+  nixfmt = if nixfmt-classic == null then nixfmt else nixfmt-classic;
+  inherit nixfmt-classic nixfmt-rfc-style;
 }


### PR DESCRIPTION
We filter out any `null` packages in tools, which triggers the `lib.warn` on `nixfmt` even if you're not using that particular hook. That makes it tricky to keep `nixfmt` around in `tools` as it is.

I've switched to `nixfmt-classic` for now 🤷 

Fixes #485.
