### PR TITLE
fix(lua-ls): only fail if there are diagnostics

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2612,7 +2612,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           };
           script = pkgs.writeShellApplication {
             name = "lua-ls-lint";
-            runtimeInputs = [ hooks.lua-ls.package ];
+            runtimeInputs = [ hooks.lua-ls.package pkgs.jq ];
             checkPhase = ""; # The default checkPhase depends on GHC
             text = ''
               set -e
@@ -2624,7 +2624,10 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               if [[ -f $logpath/check.json ]]; then
                 echo "+++++++++++++++ lua-language-server diagnostics +++++++++++++++"
                 cat $logpath/check.json
-                exit 1
+                diagnostic_count=$(jq 'length' $logpath/check.json)
+                if [ "$diagnostic_count" -gt 0 ]; then
+                  exit 1
+                fi
               fi
             '';
           };


### PR DESCRIPTION
It appears that since a recent update, lua-language-server will always output a json file (with an empty list of diagnostics if there are none).

This PR adds a check that counts the number of diagnostics, so the hook only fails if there are diagnostics.