### PR TITLE
modules: pre-commit: make pkgs.buildEnv composable

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -78,7 +78,7 @@ let
       fi
       exitcode=$?
       git --no-pager diff --color
-      touch $out
+      mkdir $out
       [ $? -eq 0 ] && exit $exitcode
     '';
 


### PR DESCRIPTION
```patch
commit 9f73309ff19bda94d6bcbe77dcd72c1c65a9f37d
[...]

    modules: pre-commit: make pkgs.buildEnv composable

    Passing a git-hooks.lib.<SYSTEM>.run derivation as a path to
    pkgs.buildEnv results in the following error due to derivations with an
    empty file being treated differently from derivations with an empty
    directory:

        The store path <TARGET> is a file and can't be merged into an
        environment using pkgs.buildEnv!

    Since Nixpkgs rejected explicitly handling derivations with an empty
    file in pkgs.buildEnv [1], affected derivations should transition from
    'touch $out' to 'mkdir $out' to be pkgs.buildEnv composable.

    This change replaces 'touch $out' with 'mkdir $out' and makes the
    following command work:

        nix \
          build \
          --expr '
            let
              flake = builtins.getFlake (toString ./.);
              system = builtins.currentSystem;
            in
              flake.inputs.nixpkgs.legacyPackages.${system}.buildEnv {
                name = "";
                paths = [(flake.outputs.lib.${system}.run {src = ./.;})];
              }
          ' \
          --impure

    [1]: https://github.com/NixOS/nixpkgs/pull/325140

    Link: https://github.com/cachix/git-hooks.nix/pull/498
```

---

For example, this PR allows me to include the `git-hooks` check in `pkgs.buildEnv`: https://github.com/trueNAHO/dotfiles/blob/4fdeb9e4e6bf6cb2255b89f5d75aab167d3bdde7/flake.nix#L707-L751
