### PR TITLE
Another attempt to fix broken statix (fixes #508)

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3479,7 +3479,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               inherit (hooks.statix) package settings;
               options = lib.cli.toGNUCommandLineShell
                 {
-                  mkList = name: value: [ name ] ++ lib.unique value;
+                  mkList = name: value: if value == [] then [] else [ name ] ++ lib.unique value;
                 }
                 settings;
             in

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3477,15 +3477,9 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           entry =
             let
               inherit (hooks.statix) package settings;
-              mkOptionName = k:
-                if builtins.stringLength k == 1
-                then "-${k}"
-                else "--${k}";
               options = lib.cli.toGNUCommandLineShell
                 {
-                  # instead of repeating the option name for each element,
-                  # create a single option with a space-separated list of unique values.
-                  mkList = k: v: [ (mkOptionName k) ] ++ lib.unique v;
+                  mkList = name: value: [ name ] ++ lib.unique value;
                 }
                 settings;
             in


### PR DESCRIPTION
One of commits introduced changes in how `statix` cli options are generated.

Fix attempt #506 was merged however it fails to resolve the issue, also, IMHO, adding unnecessary complexity, duplicating [lib.cli](https://github.com/NixOS/nixpkgs/blob/13e7885af14a46620124d2eb4008dfae3e2cfdf2/lib/cli.nix#L119) functionality

@sandydoo as #506 author, feel free to kindly comment if those changes are fine with you.