### PR TITLE
feat(run.nix): expose more

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,5 +55,7 @@
             exposed-stable.checks)));
 
       lib = forAllSystems ({ exposed, ... }: { inherit (exposed) run; });
+
+      exposed = forAllSystems ({ exposed, ... }: exposed);
     };
 }

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -35,6 +35,7 @@ let
 
 in
 project.config.run // {
+  inherit (project) config;
+  inherit (project.config) enabledPackages;
   shellHook = installationScript;
-  enabledPackages = project.config.enabledPackages;
 }


### PR DESCRIPTION
With this PR, the derivation returned by `git-hooks.lib.${system}.run { … }` contains the attribute `config`, which can be used to get the configured pre-commit-hooks. I.e. t is now possible to use the result both in the flake-outputs as e.g. `checks = { inherit pre-commit-hooks; };` as well as `apps = fooBar pre-commit-hooks.config.hooks`, where `fooBar` extracts all entries of enabled hooks so e.g. `nix run clippy` would be possible using the same CLI-options as the `checks.pre-commit-hooks`. 

If there already was a way to access these processed hooks, please document it, because I could not find a way myself.