### PR TITLE
hooks: fix rome and nixfmt migrations

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -1,20 +1,18 @@
 { config, lib, pkgs, hookModule, ... }:
 let
   inherit (lib)
-    attrNames
     boolToString
     concatStringsSep
     compare
     filterAttrs
     literalExample
     mapAttrsToList
-    mkIf
     mkOption
     types
     remove
     ;
 
-  inherit (pkgs) runCommand writeText git;
+  inherit (pkgs) runCommand git;
 
   cfg = config;
   install_stages = lib.unique (builtins.concatLists (lib.mapAttrsToList (_: h: h.stages) enabledHooks));


### PR DESCRIPTION
I've decided to go with the "duplicate the thing and move on" migration approach. Here's why:

1. `hooks.nix` doesn't operate at the submodule level. Migrations need to be added to the hooks submodule in `pre-commit.nix`, which is a bit of a mess.

2. `mkAliasOptionModule` and `mkRenamedOptionModule` work (with the above caveat). However, the former makes it impossible AFAIKT to implement warnings because of the two-way aliasing, and the latter will always spew warnings when we eval `enable`.

3. Once we split up `hooks.nix` and have each hook in a separate module, I think we can revisit hook migrations. Until then, the dumb solution is better than a half-baked smart one.

Fixes #507. Sort of. For now.