### PR TITLE
fix(rustfmt): add cargoManifestPath back

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3423,7 +3423,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               inherit (hooks) rustfmt;
               inherit (rustfmt) settings;
               cargoArgs = lib.cli.toGNUCommandLineShell { } {
-                inherit (settings) all package verbose;
+                inherit (settings) all package verbose manifest-path;
               };
               rustfmtArgs = lib.cli.toGNUCommandLineShell { } {
                 inherit (settings) check emit config-path color files-with-diff config verbose;


### PR DESCRIPTION
It seems that #504 removed the application of the option of `settings.rust.cargoManifestPath` for `rustfmt`.

This PR readds that option so that setting `settings.rust.cargoManifestPath` (or the new `rustfmt.settings.manifest-path`) adds the `--manifest-path` argument to `rustfmt`.

```nix
hooks = {
  rustfmt.enable = true;
};
settings.rust.cargoManifestPath = "backend/Cargo.toml";
}
```
now becomes:
```json
"entry": "/nix/store/04q1sh6cia6ar7zap273v3vpisf5mj7q-rustfmt-wrapped/bin/cargo-fmt fmt --all --manifest-path backend/Cargo.toml -- --color always"
```
