### PR TITLE
fix: avoid use of deprecated stage names

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ nix develop
       pre-commit-check = nix-pre-commit-hooks.run {
         src = ./.;
         # If your hooks are intrusive, avoid running on each commit with a default_states like this:
-        # default_stages = ["manual" "push"];
+        # default_stages = ["manual" "pre-push"];
         hooks = {
           elm-format.enable = true;
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2047,7 +2047,7 @@ in
           description = "Prevent very large files to be committed (e.g. binaries).";
           package = tools.pre-commit-hooks;
           entry = "${hooks.check-added-large-files.package}/bin/check-added-large-files";
-          stages = [ "commit" "push" "manual" ];
+          stages = [ "pre-commit" "pre-push" "manual" ];
         };
       check-builtin-literals =
         {
@@ -2080,7 +2080,7 @@ in
           package = tools.pre-commit-hooks;
           entry = "${hooks.check-executables-have-shebangs.package}/bin/check-executables-have-shebangs";
           types = [ "text" "executable" ];
-          stages = [ "commit" "push" "manual" ];
+          stages = [ "pre-commit" "pre-push" "manual" ];
         };
       check-json =
         {
@@ -2113,7 +2113,7 @@ in
           package = tools.pre-commit-hooks;
           entry = "${hooks.check-shebang-scripts-are-executable.package}/bin/check-shebang-scripts-are-executable";
           types = [ "text" ];
-          stages = [ "commit" "push" "manual" ];
+          stages = [ "pre-commit" "pre-push" "manual" ];
         };
       check-symlinks =
         {
@@ -3700,7 +3700,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
           name = "trim-trailing-whitespace";
           description = "Trim trailing whitespace.";
           types = [ "text" ];
-          stages = [ "commit" "push" "manual" ];
+          stages = [ "pre-commit" "pre-push" "manual" ];
           package = tools.pre-commit-hooks;
           entry = "${hooks.trim-trailing-whitespace.package}/bin/trailing-whitespace-fixer";
         };

--- a/nix/installation-test.nix
+++ b/nix/installation-test.nix
@@ -54,7 +54,7 @@ let
       expectedHooks = [ "pre-push" ];
       conf.hooks.nixpkgs-fmt = {
         enable = true;
-        stages = [ "push" ];
+        stages = [ "pre-push" ];
       };
     };
   };

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -5,7 +5,7 @@ builtinStuff@{ pkgs, tools, isFlakes, pre-commit, git, runCommand, writeText, wr
 , hooks ? { }
 , excludes ? [ ]
 , tools ? { }
-, default_stages ? [ "commit" ]
+, default_stages ? [ "pre-commit" ]
 , addGcRoot ? true
 , imports ? [ ]
 }:


### PR DESCRIPTION
These cause warnings with recent versions of pre-commit, and will be
removed in the future.
