### PR TITLE
fix: poetry option is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ clang-format supports.
 - [pylint](https://github.com/PyCQA/pylint)
 - [pyright](https://github.com/microsoft/pyright)
 - [python-debug-statements](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/debug_statement_hook.py)
-- [poetry-check](https://python-poetry.org/docs/pre-commit-hooks)
+- [poetry-check](https://python-poetry.org/docs/pre-commit-hooks): Run `poetry check`.
+- [poetry-lock](https://python-poetry.org/docs/pre-commit-hooks): Run `poetry lock`.
 - [pyupgrade](https://github.com/asottile/pyupgrade)
 - [ruff](https://github.com/charliermarsh/ruff)
 - [ruff-format](https://github.com/charliermarsh/ruff)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ clang-format supports.
 - [pylint](https://github.com/PyCQA/pylint)
 - [pyright](https://github.com/microsoft/pyright)
 - [python-debug-statements](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/debug_statement_hook.py)
-- [poetry](https://python-poetry.org/docs/pre-commit-hooks)
+- [poetry-check](https://python-poetry.org/docs/pre-commit-hooks)
 - [pyupgrade](https://github.com/asottile/pyupgrade)
 - [ruff](https://github.com/charliermarsh/ruff)
 - [ruff-format](https://github.com/charliermarsh/ruff)


### PR DESCRIPTION
`error: The option 'pre-commit.hooks.poetry.entry' is used but not defined.`