### PR TITLE
feat: add an option to `cabal2nix` hook for specifying output filename.

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -213,7 +213,7 @@ in
         type = types.submodule {
           imports = [ hookModule ];
           options.settings = {
-            output_filename =
+            outputFilename =
               mkOption {
                 type = types.str;
                 description = "The name of the output file generated after running `cabal2nix`.";
@@ -2050,7 +2050,7 @@ in
           name = "cabal2nix";
           description = "Run `cabal2nix` on all `*.cabal` files to generate corresponding `.nix` files";
           package = tools.cabal2nix-dir;
-          entry = "${hooks.cabal2nix.package}/bin/cabal2nix-dir --outputFileName=${hooks.cabal2nix.settings.output_filename}";
+          entry = "${hooks.cabal2nix.package}/bin/cabal2nix-dir --outputFileName=${hooks.cabal2nix.settings.outputFilename}";
           files = "\\.cabal$";
           after = [ "hpack" ];
         };

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -208,6 +208,20 @@ in
           };
         };
       };
+      cabal2nix = mkOption {
+        description = "cabal2nix hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            output_filename =
+              mkOption {
+                type = types.str;
+                description = "The name of the output file generated after running `cabal2nix`.";
+                default = "default.nix";
+              };
+          };
+        };
+      };
       clippy = mkOption {
         description = "clippy hook";
         type = types.submodule
@@ -2034,9 +2048,9 @@ in
       cabal2nix =
         {
           name = "cabal2nix";
-          description = "Run `cabal2nix` on all `*.cabal` files to generate corresponding `default.nix` files";
+          description = "Run `cabal2nix` on all `*.cabal` files to generate corresponding `.nix` files";
           package = tools.cabal2nix-dir;
-          entry = "${hooks.cabal2nix.package}/bin/cabal2nix-dir";
+          entry = "${hooks.cabal2nix.package}/bin/cabal2nix-dir --outputFileName=${hooks.cabal2nix.settings.output_filename}";
           files = "\\.cabal$";
         };
       cargo-check =

--- a/nix/cabal2nix-dir/default.nix
+++ b/nix/cabal2nix-dir/default.nix
@@ -2,10 +2,21 @@
 
 writeScriptBin "cabal2nix-dir" ''#!/usr/bin/env bash
   projectdir="$(pwd)"
-  for cabalFile in "''$@"; do
+  outputFileName=""
+  cabalFiles=()
+
+  for arg in "$@"; do
+    if [[ "$arg" == --outputFileName=* ]]; then
+      outputFileName="''${arg#--outputFileName=}"
+    else
+      cabalFiles+=("$arg")
+    fi
+  done
+
+  for cabalFile in "''${cabalFiles[@]}"; do
     echo "$cabalFile"
     dir="$(dirname $cabalFile)"
     cd "$projectdir/$dir"
-    ${cabal2nix}/bin/cabal2nix --no-hpack . > default.nix
+    ${cabal2nix}/bin/cabal2nix --no-hpack . > "$outputFileName"
   done
 ''


### PR DESCRIPTION
At present after enabling `cabal2nix` hook, it generates a file named `default.nix` which is hardcoded. It is better if user has an option to specify the filename instead of using hardcoded `default.nix`.

This PR adds an option to `cabal2nix` hook to specify output filename generated by running `cabal2nix`.

Example: 

```
cabal2nix = {
   enable = true;
   settings.output_filename = "cabal.nix";
};
```