### PR TITLE
make sure that clang-tools is in the same version across all platforms

### DIFF
--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -11,7 +11,7 @@
 , callPackage
 , cargo
 , checkmake
-, clang-tools
+, llvmPackages_latest
 , clippy
 , cljfmt
 , cmake-format
@@ -96,6 +96,7 @@ let
   };
 in
 {
+  clang-tools = llvmPackages_latest.clang-tools;
   inherit
     actionlint
     alejandra
@@ -106,7 +107,6 @@ in
     cabal-fmt
     cabal-gild
     cargo
-    clang-tools
     clippy
     cljfmt
     cmake-format


### PR DESCRIPTION
We noticed when upgrading nixpkgs in nix, that clang-format would produce different results on macOS vs Linux.
This is not great behaviour especially in CI, because you cannot win. This is because llvmPackage might be in a different version. To solve this, we now always depend on the latest version.