### PR TITLE
chore: add a default priority between `cabal2nix` & `hpack`

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2038,6 +2038,7 @@ in
           package = tools.cabal2nix-dir;
           entry = "${hooks.cabal2nix.package}/bin/cabal2nix-dir";
           files = "\\.cabal$";
+          after = [ "hpack" ];
         };
       cargo-check =
         {


### PR DESCRIPTION
Set a default priority between `cabal2nix` and `hpack` which ensures if `cabal2nix` is enabled in the hook then it will run after `hpack` so that there is no staleness.