### PR TITLE
bugfix: remove before/after options from config json file

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -9,6 +9,7 @@ let
     mapAttrsToList
     mkOption
     types
+    removeAttrs
     remove
     ;
 
@@ -43,8 +44,15 @@ let
           )
           enabledHooks
         );
+      cleanedHooks = builtins.map (
+        hook:
+        removeAttrs hook [
+          "before"
+          "after"
+        ]
+      ) sortedHooks.result;
     in
-    sortedHooks.result;
+    cleanedHooks;
 
   configFile =
     performAssertions (


### PR DESCRIPTION
A recent commit to add ordering priority to the hooks introduced new keys into the pre-commit JSON config file. These keys should not be there are they are not keys pre-commit is aware of and produce warning messages. e.g.:

```
[WARNING] Unexpected key(s) present on local => treefmt: after, before
```

This commit fixes it by filter out all keys with names `before` or `after`, in Nix, before writing the configuration to file.

Fixes https://github.com/cachix/git-hooks.nix/issues/112