### PR TITLE
Improve `before` and `after` internal logic

### DIFF
--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -25,10 +25,39 @@ in
         '';
     };
 
+    id = mkOption {
+      type = types.str;
+      default = name;
+      defaultText = "the attribute name the hook submodule is bound to";
+      description =
+        ''
+          The unique identifier for the hook.
+
+          You do not need to set or modify this value.
+
+          The `id` is used to reference a hook when using `pre-commit run <id>`.
+          It can also be used to reference the hook in other hooks' `before` and `after` fields to define the order in which hooks run.
+
+          The `id` is set to the attribute name the hook submodule is bound to in the parent module.
+          For example, the `id` of following hook would be `my-hook`.
+
+          ```nix
+          {
+            hooks = {
+              my-hook = {
+                enable = true;
+                entry = "my-hook";
+              };
+            }
+          }
+          ```
+        '';
+    };
+
     name = mkOption {
       type = types.str;
-      defaultText = lib.literalMD "internal name, same as `id`";
       default = name;
+      defaultText = lib.literalMD "the attribute name the hook submodule is bound to, same as `id`";
       description =
         ''
           The name of the hook. Shown during hook execution.
@@ -202,14 +231,12 @@ in
         '';
       default = [ ];
     };
-
   };
 
   config = {
     raw =
       {
-        inherit (config) name entry language files types types_or exclude_types pass_filenames fail_fast require_serial stages verbose always_run args before after;
-        id = config.name;
+        inherit (config) id name entry language files types types_or exclude_types pass_filenames fail_fast require_serial stages verbose always_run args;
         exclude = mergeExcludes config.excludes;
       };
   };

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -9,7 +9,6 @@ let
     mapAttrsToList
     mkOption
     types
-    removeAttrs
     remove
     ;
 
@@ -34,25 +33,9 @@ let
     let
       sortedHooks = lib.toposort
         (a: b: builtins.elem b.id a.before || builtins.elem a.id b.after)
-        (mapAttrsToList
-          (id: value:
-            value.raw // {
-              inherit id;
-              before = value.raw.before;
-              after = value.raw.after;
-            }
-          )
-          enabledHooks
-        );
-      cleanedHooks = builtins.map (
-        hook:
-        removeAttrs hook [
-          "before"
-          "after"
-        ]
-      ) sortedHooks.result;
+        (builtins.attrValues enabledHooks);
     in
-    cleanedHooks;
+    builtins.map (value: value.raw) sortedHooks.result;
 
   configFile =
     performAssertions (


### PR DESCRIPTION
Consolidates and improves upon the work in #533 and #536.

- Removes `before` and `after` from the `raw` config, initially added in #533. These are not valid pre-commit configuration options and should not be here.
- Removes code to filter out `before` and `after` from the `raw` config.
  There's nothing to filter out if they're not in the config in the first place. Essentially, reverts #536.
- Adds a pretty-ish error message (most of the diff) if the hooks cannot be sorted. Instead of erroring out on an obscure missing `result` field, we now show:
  ```
         error: The hooks can't be sorted because of a cycle in the dependency graph:

         nixpkgs-fmt -> shellcheck -> typos

         which leads to a loop back to: shellcheck

       Try removing the conflicting hook ids from the `before` and `after` attributes of these hooks:

         {
           nixpkgs-fmt = {
             after = [ ];
             before = [ ];
           };
           shellcheck = {
             after = [ ];
             before = [
               "nixpkgs-fmt"
               "typos"
             ];
           };
           typos = {
             after = [ ];
             before = [
               "shellcheck"
             ];
           };
         }
   ```
- Sets `id` to the attr name of the hook, instead of the `name`. This corrects a mistake made in the module transition (https://github.com/cachix/git-hooks.nix/pull/397). Technically, a breaking change, but we haven't had feedback from the initial mistake.
- Exposes `id` in the options.