### PR TITLE
fix: pre-commit errors due to polluted git directory

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -95,6 +95,10 @@ let
       buildPhase = ''
         set +e
         HOME=$PWD
+        # It is important to use a separate git directory than $HOME,
+        # so pre-commit artifacts won't pollute it
+        mkdir src
+        cd src
         ln -fs ${configFile} .pre-commit-config.yaml
         git init -q
         git add .


### PR DESCRIPTION
After #396, `reuse` hook no longer works, as it considers untracked files added by `pre-commit`. Before the above PR, the git repository was in `$HOME/src`, so files added in `$HOME` didn't affect the outcome of the hooks themselves.

This change re-adds the `src` subdirectory.

A failing build output:

     $ nix build --no-link -L .\#checks.x86_64-linux.pre-commit
     Running phase: unpackPhase
     unpacking source archive /nix/store/g1p6g2ylflj4fnzdwlc368737kxk0p9f-source
     source root is source
     Running phase: patchPhase
     Running phase: updateAutotoolsGnuConfigScriptsPhase
     Running phase: configurePhase
     no configure script, doing nothing
     Running phase: buildPhase
     Running: $ pre-commit run --all-files
     reuse....................................................................Failed
     - hook id: reuse
     - exit code: 1
     # MISSING COPYRIGHT AND LICENSING INFORMATION
     The following files have no copyright and licensing information:
     * .cache/pre-commit/README
     * .cache/pre-commit/db.db
     * .gitconfig
     # SUMMARY
     * Bad licenses: 0
     * Deprecated licenses: 0
     * Licenses without file extension: 0
     * Missing licenses: 0
     * Unused licenses: 0
     * Used licenses: MIT
     * Read errors: 0
     * Files with copyright information: 16 / 19
     * Files with license information: 16 / 19
     Unfortunately, your project is not compliant with version 3.3 of the REUSE Specification :-(
     # RECOMMENDATIONS
     * Fix missing copyright/licensing information: For one or more files, the tool
       cannot find copyright and/or licensing information. You typically do this by
       adding 'SPDX-FileCopyrightText' and 'SPDX-License-Identifier' tags to each
       file. The tutorial explains additional ways to do this:
       <https://reuse.software/tutorial/>