### PR TITLE
docs: add `trufflehog` entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ clang-format supports.
 - [topiary](https://github.com/tweag/topiary)
 - [treefmt](https://github.com/numtide/treefmt)
 - [trim-trailing-whitespace](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/trailing_whitespace_fixer.py)
+- [trufflehog](https://github.com/trufflesecurity/trufflehog): Secret scanner
 
 ### Custom hooks
 


### PR DESCRIPTION
Found this when looking at the source. I think it is worth mentioning, as it is useful arleady?

references #441 