### PR TITLE
check: set HOME to a tmp dir to avoid polluting the working dir

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -86,7 +86,6 @@ let
   run =
     mkDerivation {
       name = "pre-commit-run";
-
       src = cfg.rootSrc;
       buildInputs = [ cfg.gitPackage ];
       nativeBuildInputs = enabledExtraPackages
@@ -94,7 +93,8 @@ let
       cargoDeps = config.settings.rust.check.cargoDeps;
       buildPhase = ''
         set +e
-        HOME=$PWD
+        # Set HOME to a temporary directory for pre-commit to create its cache files in.
+        HOME=$(mktemp -d)
         ln -fs ${configFile} .pre-commit-config.yaml
         git init -q
         git add .
@@ -111,6 +111,7 @@ let
         fi
         exitcode=$?
         git --no-pager diff --color
+        # Derivations must produce an output
         mkdir $out
         [ $? -eq 0 ] && exit $exitcode
       '';


### PR DESCRIPTION
pre-commit creates cache files in `$HOME/.cache/pre-commit`. If `$HOME` is set to `$PWD`, we will pollute the working directory, causing hook failures.

Previously, we would copy the source files into a nested `src` directory. Now that Nix already provides the source files in the working directory for us, to avoid another copy, we set `$HOME` to a temporary directory.