### PR TITLE
yamlfmt: allow formatting during hook run

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1875,6 +1875,12 @@ in
                 default = "";
                 example = ".yamlfmt";
               };
+            lint-only =
+              mkOption {
+                type = types.bool;
+                description = "Only lint the files, do not format them in place.";
+                default = true;
+              };
           };
         };
       };
@@ -3878,10 +3884,10 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormol
               cmdArgs =
                 mkCmdArgs
                   (with hooks.yamlfmt.settings; [
-                    # Exit non-zero on changes
-                    [ true "-lint" ]
-                    # But do not print the diff
-                    [ true "-quiet" ]
+                    # Exit with non-zero status if the file is not formatted
+                    [ lint-only "-lint" ]
+                    # Do not print the diff
+                    [ lint-only "-quiet" ]
                     # See https://github.com/google/yamlfmt/blob/main/docs/config-file.md#config-file-discovery
                     [ (configPath != "") "-conf ${configPath}" ]
                   ]);


### PR DESCRIPTION
The -lint option ensures that yamlfmt exits with a nonzero code if some files are not formatted correctly but does not actually modify the files. Running without the -lint modifies the files in place (which also aborts the commit during pre-commit since the files were modified).

This change exposes the option to be able to toggle the behavior to fail to commit on bad formatting, vs fail while fixing the formatting.