### PR TITLE
fix(fourmolu): refer to its own settings

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -603,6 +603,17 @@ in
           };
         };
       };
+      fourmolu = mkOption {
+        description = "fourmolu hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings.defaultExtensions = mkOption {
+            type = types.listOf types.str;
+            description = "Haskell language extensions to enable.";
+            default = [ ];
+          };
+        };
+      };
       golines = mkOption {
         description = "golines hook";
         type = types.submodule {
@@ -2630,7 +2641,7 @@ in
           package = tools.fourmolu;
           entry =
             "${hooks.fourmolu.package}/bin/fourmolu --mode inplace ${
-lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.ormolu.settings.defaultExtensions)
+lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourmolu.settings.defaultExtensions)
 }";
           files = "\\.l?hs(-boot)?$";
         };


### PR DESCRIPTION
The `fourmolu` hook refers to `ormolu`'s settings which, as I suppose, is a mistake. This PR configures `fourmolu` to refer to its own settings.
