### PR TITLE
Exposes configPath to the run wrapper

### DIFF
--- a/nix/run.nix
+++ b/nix/run.nix
@@ -8,6 +8,7 @@ builtinStuff@{ pkgs, tools, isFlakes, pre-commit, git, runCommand, writeText, wr
 , default_stages ? [ "pre-commit" ]
 , addGcRoot ? true
 , imports ? [ ]
+, configPath ? ".pre-commit-config.yaml"
 }:
 let
   project =
@@ -20,7 +21,7 @@ let
               {
                 _module.args.pkgs = pkgs;
                 _module.args.gitignore-nix-src = gitignore-nix-src;
-                inherit hooks excludes default_stages settings addGcRoot;
+                inherit hooks excludes default_stages settings addGcRoot configPath;
                 tools = builtinStuff.tools // tools;
                 package = pre-commit;
               } // (if isFlakes


### PR DESCRIPTION
What

- Adds configPath to the run wrapper arguments as well as the module configuration 

Why

- I was just testing this on my machine and the configPath option wasn't available when calling the run wrapper

The following snippet of configuration is now working for me with this change

```nix
        pre-commit-check = pre-commit-hooks.lib.${system}.run {
          src = ./.;
          configPath = ".pre-commit-config-nix.yaml";
          hooks = {
            end-of-file-fixer.enable = true;
            flake-checker.enable = true;
            nil.enable = true;
            trim-trailing-whitespace.enable = true;
            trufflehog.enable = true;
          };
        };
```

See https://github.com/willfish/nix/blob/master/flake.nix for working implementation against my fork of this flake