### PR TITLE
vale: fix outdated configuration variable name

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4039,7 +4039,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
         entry =
           let
             # TODO: was .vale.ini, threw error in Nix
-            configFile = builtins.toFile "vale.ini" "${hooks.vale.settings.config}";
+            configFile = builtins.toFile "vale.ini" "${hooks.vale.settings.configuration}";
             cmdArgs =
               mkCmdArgs
                 (with hooks.vale.settings; [


### PR DESCRIPTION
f94f8e2 (Remove shadowing of `config` attribute in hooks, 2024-02-16) renamed the setting "config" to "configuration", but forgot to update the reference to it. Update it now.