### PR TITLE
Add `nbstripout` hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -913,6 +913,12 @@ in
           };
         };
       };
+      nbstripout = mkOption {
+        description = "nbstripout hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+        };
+      };
       nixfmt = mkOption {
         description = "Deprecated nixfmt hook. Use nixfmt-classic or nixfmt-rfc-style instead.";
         visible = false;
@@ -3233,6 +3239,14 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
           package = tools.pre-commit-hooks;
           entry = "${hooks.name-tests-test.package}/bin/tests_should_end_in_test.py";
           files = "(^|/)tests/\.+\\.py$";
+        };
+      nbstripout =
+        {
+          name = "nbstripout";
+          description = "Strip output from Jupyter notebooks";
+          package = tools.nbstripout;
+          entry = "${hooks.nbstripout.package}/bin/nbstripout";
+          files = "\\.ipynb$";
         };
       nil =
         {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -47,6 +47,7 @@
 , mdformat
 , mdl
 , mdsh
+, nbstripout
 , nil
 , nixfmt
 , nixfmt-classic ? null
@@ -145,6 +146,7 @@ in
     mdformat
     mdl
     mdsh
+    nbstripout
     nil
     nixpkgs-fmt
     opentofu


### PR DESCRIPTION
Adds a simple hook for https://github.com/kynan/nbstripout. Requires the use of nixpkgs-unstable because nbstriput is broken without https://github.com/NixOS/nixpkgs/commit/0090bf428c629c4b516fab58fef41ec4dce11e06. 