### PR TITLE
fix(govet): change to dir before running

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2894,7 +2894,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
               script = pkgs.writeShellScript "precommit-govet" ''
                 set -e
                 for dir in $(echo "$@" | xargs -n1 dirname | sort -u); do
-                  ${hooks.govet.package}/bin/go vet ./"$dir"
+                  ${hooks.govet.package}/bin/go vet -C ./"$dir"
                 done
               '';
             in


### PR DESCRIPTION
This should work as now for single-module repos, but should add support for monorepos with multiple Go modules, e.g., https://github.com/golang/tools.