### PR TITLE
Fix (trufflehog): Remove renundant `--no-update` causing it to fail

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3972,7 +3972,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             let
               script = pkgs.writeShellScript "precommit-trufflehog" ''
                 set -e
-                ${hooks.trufflehog.package}/bin/trufflehog --no-update git "file://$(git rev-parse --show-toplevel)" --since-commit HEAD --only-verified --fail
+                ${hooks.trufflehog.package}/bin/trufflehog git "file://$(git rev-parse --show-toplevel)" --since-commit HEAD --only-verified --fail
               '';
             in
             builtins.toString script;


### PR DESCRIPTION
Trufflehog was failing due to multiple no update flags being passed.

Fix: remove the `--no-update` from the hook to remove the redundantly sourced no update prompt.

```
trufflehog...............................................................Failed
- hook id: trufflehog
- exit code: 1

trufflehog: error: flag 'no-update' cannot be repeated, try --help
```
