### PR TITLE
feat: add action-validator hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ use nix
 ### Various other hooks
 
 - [actionlint](https://github.com/rhysd/actionlint)
+- [action-validator](https://github.com/mpalmer/action-validator)
 - [check-added-large-files](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_added_large_files.py)
 - [check-case-conflicts](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_case_conflict.py)
 - [check-executables-have-shebangs](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_executables_have_shebangs.py)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2046,6 +2046,15 @@ in
           package = tools.actionlint;
           entry = "${hooks.actionlint.package}/bin/actionlint";
         };
+      action-validator =
+        {
+          name = "action-validator";
+          description = "Tool to validate GitHub Action and Workflow YAML files";
+          files = "^.github/(actions|workflows)/";
+          types = [ "yaml" ];
+          package = tools.action-validator;
+          entry = "${hooks.action-validator.package}/bin/action-validator";
+        };
       alejandra =
         {
           name = "alejandra";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -2,6 +2,7 @@
 , lib
 
 , actionlint
+, action-validator
 , alejandra
 , ansible-lint
 , biome
@@ -106,6 +107,7 @@ in
   clang-tools = llvmPackages_latest.clang-tools;
   inherit
     actionlint
+    action-validator
     alejandra
     ansible-lint
     beautysh


### PR DESCRIPTION
This commit introduces configuration for
[action-validator](https://github.com/mpalmer/action-validator), a tool
for validating both workflow and action YAML files. I think this is a
worthy addition to the project as it complements the existing
`actionlint` tool, which seems to only validate workflow files.

Signed-off-by: squat <lserven@gmail.com>
