### PR TITLE
Use the manual hook stage if it exists in the list

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -3,7 +3,7 @@ let
   inherit (lib)
     boolToString
     concatStringsSep
-    compare
+    elem
     filterAttrs
     literalExample
     mapAttrsToList
@@ -101,7 +101,7 @@ let
         git config --global user.email "you@example.com"
         git config --global user.name "Your Name"
         git commit -m "init" -q
-        if [[ ${toString (compare cfg.installStages [ "manual" ])} -eq 0 ]]
+        if [[ '${toString (elem "manual" cfg.installStages)}' -eq '1' ]]
         then
           echo "Running: $ pre-commit run --hook-stage manual --all-files"
           pre-commit run -c ${cfg.configPath} --hook-stage manual --all-files


### PR DESCRIPTION
Since #415 seems not maintained anymore and it hinders our workflow I've created a simple workaround.

The issue is, that `pre-commit` without a `--hook-stage` uses the `commit` stage.
Now we have `["pre-push" "manual"]` as the `installStages` defined.
Because of that it does not match the current `compare` and which lead to the the commit stage being used., which contains no tasks.

This change uses the `manual` stage if it exists anywhere in the `installStages` list.