### PR TITLE
chore(checkmake): Remove outdated version checks and comments

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2221,13 +2221,7 @@ in
         description = "Experimental linter/analyzer for Makefiles";
         types = [ "makefile" ];
         package = tools.checkmake;
-        entry =
-          ## NOTE: `checkmake` 0.2.2 landed in nixpkgs on 12 April 2023. Once
-          ## this gets into a NixOS release, the following code will be useless.
-          lib.throwIf
-            (hooks.checkmake.package == null)
-            "The version of nixpkgs used by git-hooks.nix must have `checkmake` in version at least 0.2.2 for it to work on non-Linux systems."
-            "${hooks.checkmake.package}/bin/checkmake";
+        entry = "${hooks.checkmake.package}/bin/checkmake";
       };
       check-added-large-files =
         {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -115,6 +115,7 @@ in
     cabal-fmt
     cabal-gild
     cargo
+    checkmake
     circleci-cli
     clippy
     cljfmt
@@ -214,10 +215,6 @@ in
   git-annex = if stdenv.isDarwin then null else git-annex;
   # Note: Only broken in stable nixpkgs, works fine on latest master.
   opam = if stdenv.isDarwin then null else opam;
-
-  ## NOTE: `checkmake` 0.2.2 landed in nixpkgs on 12 April 2023. Once this gets
-  ## into a NixOS release, the following code will be useless.
-  checkmake = if stdenv.isLinux || checkmake.version >= "0.2.2" then checkmake else null;
 
   headache = callPackage ./headache { };
 


### PR DESCRIPTION
checkmake 0.2.2 has shipped with the last several stable releases of nixpkgs.

Tagging @Niols for review as the original author of the checkmake entry.