### PR TITLE
Fix exclude param propagation for typos hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4024,7 +4024,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                     [ (configuration != "") "--config ${configFile}" ]
                     [ (configPath != "" && configuration == "") "--config ${configPath}" ]
                     [ diff "--diff" ]
-                    [ (exclude != "") "--exclude ${exclude} --force-exclude" ]
+                    [ (exclude != "") "--exclude '${exclude}' --force-exclude" ]
                     [ (format != "long") "--format ${format}" ]
                     [ hidden "--hidden" ]
                     [ (locale != "en") "--locale ${locale}" ]


### PR DESCRIPTION
Simple fix for: Typos exclude param implementation failing for globs #618