### PR TITLE
Do not pass filenames to ansible-lint by default

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2131,6 +2131,7 @@ in
             in
             "${hooks.ansible-lint.package}/bin/ansible-lint ${cmdArgs}";
           files = if hooks.ansible-lint.settings.subdir != "" then "${hooks.ansible-lint.settings.subdir}/" else "";
+          pass_filenames = false;
         };
       autoflake =
         {


### PR DESCRIPTION
This causes ansible-lint to ignore some of the settings (mainly exclude_paths) which is annoying to debug as ansible-lint's behavior changes between pre-commit hook and manual invocation