### PR TITLE
modules/pre-commit: make `rawConfig` option type recursively updatable

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -368,7 +368,7 @@ in
 
       rawConfig =
         mkOption {
-          type = types.attrs;
+          type = types.attrsOf types.unspecified;
           description =
             ''
               The raw configuration before writing to file.


### PR DESCRIPTION
`lib.types.attrs` does not recursively update attribute values. It simply overwrites them. Because of this behavior, the code on line 427 does not allow setting own `rawConfig.repos` at all:  

```nix
    rawConfig =
      {
        repos =
          [
            {
              repo = "local";
              hooks = processedHooks;
            }
          ];
      } // lib.optionalAttrs (cfg.excludes != [ ]) {
        exclude = mergeExcludes cfg.excludes;
      } // lib.optionalAttrs (cfg.default_stages != [ ]) {
        default_stages = cfg.default_stages;
      };
```
