### PR TITLE
feat: add chart-testing hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ use nix
 
 - [actionlint](https://github.com/rhysd/actionlint)
 - [action-validator](https://github.com/mpalmer/action-validator)
+- [chart-testing](https://github.com/helm/chart-testing)
 - [check-added-large-files](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_added_large_files.py)
 - [check-case-conflicts](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_case_conflict.py)
 - [check-executables-have-shebangs](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/check_executables_have_shebangs.py)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2311,6 +2311,15 @@ in
           files = "\\.rs$";
           pass_filenames = false;
         };
+      chart-testing =
+        {
+          name = "chart-testing";
+          description = "CLI tool for linting and testing Helm charts";
+          files = "^charts/";
+          package = tools.chart-testing;
+          entry = "${pkgs.chart-testing}/bin/ct lint --all --skip-helm-dependencies";
+          pass_filenames = false;
+        };
       checkmake = {
         name = "checkmake";
         description = "Experimental linter/analyzer for Makefiles";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -11,6 +11,7 @@
 , cabal2nix
 , callPackage
 , cargo
+, chart-testing
 , checkmake
 , circleci-cli
 , llvmPackages_latest
@@ -121,6 +122,7 @@ in
     cabal-fmt
     cabal-gild
     cargo
+    chart-testing
     checkmake
     circleci-cli
     clippy


### PR DESCRIPTION
This commit introduces configuration for
[chart-testing](https://github.com/helm/chart-testing), a tool for
validating Helm charts.

The default usage of the tool assumes that Helm charts are nested within
`^charts/` at the root of the directory, and this pre-commit hook makes
the same assumption.

Signed-off-by: squat <lserven@gmail.com>
