### PR TITLE
feat: add badness hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ hooks](modules/pre-commit.nix).
 
 ### LaTeX
 
+- [badness](https://github.com/jolars/badness)
 - [chktex](https://www.nongnu.org/chktex/)
 - [lacheck](https://ctan.org/pkg/lacheck)
 - [latexindent](https://github.com/cmhughes/latexindent.pl)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2696,6 +2696,24 @@ in
             "${binPath} ${hooks.autoflake.settings.flags}";
           types = [ "python" ];
         };
+      badness-format =
+        {
+          name = "badness-format";
+          description = "Format LaTeX and BibTeX files with badness.";
+          package = tools.badness;
+          entry = "${lib.getExe hooks.badness-format.package} format --force-exclude";
+          files = "\\.(tex|sty|cls|dtx|ins|bib)$";
+          require_serial = true;
+        };
+      badness-lint =
+        {
+          name = "badness-lint";
+          description = "Lint LaTeX and BibTeX files with badness.";
+          package = tools.badness;
+          entry = "${lib.getExe hooks.badness-lint.package} lint --force-exclude";
+          files = "\\.(tex|sty|cls|dtx|ins|bib)$";
+          require_serial = true;
+        };
       biome =
         {
           name = "biome";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -7,6 +7,7 @@
 , air-formatter
 , alejandra
 , ansible-lint
+, badness ? placeholder "badness"
 , biome
 , cabal2nix
 , callPackage
@@ -136,6 +137,7 @@ in
     action-validator
     alejandra
     ansible-lint
+    badness
     beautysh
     biome
     cabal2nix


### PR DESCRIPTION
Add separate formatting and linting hooks for LaTeX and BibTeX files. The lint hook reports findings by default and accepts `--fix` through the generic hook arguments.

Badness (https://badness.dev) is a language server, formatter, and linter for LaTeX.