### PR TITLE
feat: add fatou hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ hooks](modules/pre-commit.nix).
 
 ### Julia
 
+- [fatou](https://github.com/jolars/fatou)
 - [JuiaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl)
 
 ### LaTeX

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3302,6 +3302,24 @@ in
             "${binPath} --fix";
           files = "${hooks.eslint.settings.extensions}";
         };
+      fatou-format =
+        {
+          name = "fatou-format";
+          description = "Format Julia files with fatou.";
+          package = tools.fatou;
+          entry = "${lib.getExe hooks.fatou-format.package} format --force-exclude";
+          files = "\\.jl$";
+          require_serial = true;
+        };
+      fatou-lint =
+        {
+          name = "fatou-lint";
+          description = "Lint Julia files with fatou.";
+          package = tools.fatou;
+          entry = "${lib.getExe hooks.fatou-lint.package} lint --force-exclude";
+          files = "\\.jl$";
+          require_serial = true;
+        };
       fix-byte-order-marker =
         {
           name = "fix-byte-order-marker";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -36,6 +36,7 @@
 , elixir
 , elmPackages
 , eslint
+, fatou ? placeholder "fatou"
 , flake-checker ? placeholder "flake-checker"
 , fprettify
 , git-annex
@@ -161,6 +162,7 @@ in
     editorconfig-checker
     elixir
     eslint
+    fatou
     flake-checker
     fprettify
     git-annex


### PR DESCRIPTION
Add separate formatting and linting hooks for Julia files. The lint hook reports findings by default and accepts `--fix` through the generic hook arguments.

Fatou (https://fatou.dev) is a formatter, linter, and language server for Julia.