### PR TITLE
feat: add arity hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ hooks](modules/pre-commit.nix).
 ### R
 
 - [air](https://github.com/posit-dev/air)
+- [arity](https://github.com/jolars/arity)
 
 ### Rego (Open Policy Agent)
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2683,6 +2683,24 @@ in
           files = if hooks.ansible-lint.settings.subdir != "" then "${hooks.ansible-lint.settings.subdir}/" else "";
           pass_filenames = false;
         };
+      arity-format =
+        {
+          name = "arity-format";
+          description = "Format R files and DESCRIPTION files with arity.";
+          package = tools.arity;
+          entry = "${lib.getExe hooks.arity-format.package} format --force-exclude";
+          files = "(^|/)(DESCRIPTION|[^/]*\\.[rR])$";
+          require_serial = true;
+        };
+      arity-lint =
+        {
+          name = "arity-lint";
+          description = "Lint R files with arity.";
+          package = tools.arity;
+          entry = "${lib.getExe hooks.arity-lint.package} lint --force-exclude";
+          files = "\\.[rR]$";
+          require_serial = true;
+        };
       autoflake =
         {
           name = "autoflake";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -7,6 +7,7 @@
 , air-formatter
 , alejandra
 , ansible-lint
+, arity ? placeholder "arity"
 , biome
 , cabal2nix
 , callPackage
@@ -136,6 +137,7 @@ in
     action-validator
     alejandra
     ansible-lint
+    arity
     beautysh
     biome
     cabal2nix


### PR DESCRIPTION
Add separate formatting and linting hooks for R projects. The formatter also handles DESCRIPTION files, while the linter reports findings without applying fixes by default.

Arity (https://arity.cc) is a formatter, linter, and language server for R.