### PR TITLE
fix(nufmt): match .nu files instead of unrecognized type tag

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4024,7 +4024,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                   ]);
             in
             "${lib.getExe hooks.nufmt.package} ${cmdArgs}";
-          types = [ "nushell" ];
+          files = "\\.nu$";
         };
       ocp-indent =
         {


### PR DESCRIPTION
### Summary

Fixes the `nufmt` hook configuration so it can actually run under `pre-commit`.

### Context

In b915811072666d144e33bfebc50890507b05bb6f (#699 by @asakura), the `nufmt` hook was introduced with `types = [ "nushell" ];`.

However, `pre-commit` validates file type tags against the [identify](https://github.com/pre-commit/identify) tag registry. Because `identify` does not define a `nushell` tag, enabling `nufmt` currently causes `pre-commit` to crash during configuration validation:

```
An error has occurred: InvalidConfigError:
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='local')
==> At key: hooks
==> At Hook(id='nufmt')
==> At key: types
==> At index 0
=====> Type tag 'nushell' is not recognized.  Try upgrading identify and pre-commit?
```

### Solution

Following the convention of other hooks in this repository for file formats not tracked by `identify` (e.g. Elm, Dhall, OPAM, Typst), replace `types = [ "nushell" ];` with:

```nix
files = "\\.nu$";
```

(Since `types` defaults to `[ "file" ]` in `modules/hook.nix`, this properly restricts `nufmt` to Nushell source files without triggering `identify` validation errors).

### Verification

Tested with a consumer flake importing this modified `git-hooks.nix` with `pre-commit.settings.hooks.nufmt.enable = true;`. Pre-commit successfully invoked `nufmt` on `.nu` files and passed all checks.