### PR TITLE
feat(nushell): add nu-check and nu-lint hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ hooks](modules/pre-commit.nix).
 ### Nushell
 
 - [nu-check](https://www.nushell.sh/commands/docs/nu-check.html)
+- [nu-lint](https://codeberg.org/wvhulle/nu-lint)
 - [nufmt](https://github.com/nushell/nufmt)
 
 ### OCaml

--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ hooks](modules/pre-commit.nix).
 
 ### Nushell
 
+- [nu-check](https://www.nushell.sh/commands/docs/nu-check.html)
 - [nufmt](https://github.com/nushell/nufmt)
 
 ### OCaml

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1103,6 +1103,15 @@ in
           };
         };
       };
+      nu-check = mkOption {
+        description = "nu-check hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            asModule = mkEnableOption "parsing content as module";
+          };
+        };
+      };
       nufmt = mkOption {
         description = "nufmt hook";
         type = types.submodule {
@@ -4009,6 +4018,18 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                   ]);
             in
             "${hooks.no-commit-to-branch.package}/bin/no-commit-to-branch ${cmdArgs}";
+        };
+      nu-check =
+        {
+          name = "nu-check";
+          description = "Validate and parse Nushell scripts.";
+          package = tools.nushell;
+          entry =
+            let
+              asModuleFlag = lib.optionalString hooks.nu-check.settings.asModule "--as-module ";
+            in
+            "${lib.getExe hooks.nu-check.package} -c 'def main [...files: string] { mut err = false; for f in $files { if not (nu-check --debug ${asModuleFlag}($f | path expand)) { $err = true } }; if $err { exit 1 } }' --";
+          files = "\\.nu$";
         };
       nufmt =
         {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1112,6 +1112,20 @@ in
           };
         };
       };
+      nu-lint = mkOption {
+        description = "nu-lint hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            configPath = mkOption {
+              type = types.nullOr types.path;
+              description = "Path to the nu-lint configuration file.";
+              default = null;
+            };
+            fix = mkEnableOption "automatically fixing lint violations";
+          };
+        };
+      };
       nufmt = mkOption {
         description = "nufmt hook";
         type = types.submodule {
@@ -4029,6 +4043,23 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
               asModuleFlag = lib.optionalString hooks.nu-check.settings.asModule "--as-module ";
             in
             "${lib.getExe hooks.nu-check.package} -c 'def main [...files: string] { mut err = false; for f in $files { if not (nu-check --debug ${asModuleFlag}($f | path expand)) { $err = true } }; if $err { exit 1 } }' --";
+          files = "\\.nu$";
+        };
+      nu-lint =
+        {
+          name = "nu-lint";
+          description = "A linter for Nushell scripts.";
+          package = tools.nu-lint;
+          entry =
+            let
+              cmdArgs =
+                mkCmdArgs
+                  (with hooks.nu-lint.settings; [
+                    [ (configPath != null) "--config ${configPath}" ]
+                    [ fix "--fix" ]
+                  ]);
+            in
+            "${lib.getExe hooks.nu-lint.package} ${cmdArgs}";
           files = "\\.nu$";
         };
       nufmt =

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -64,6 +64,7 @@
 , nixfmt-classic ? placeholder "nixfmt-classic"
 , nixfmt-rfc-style ? placeholder "nixfmt-rfc-style"
 , nixpkgs-fmt
+, nu-lint ? placeholder "nu-lint"
 , nushell ? placeholder "nushell"
 , nufmt ? placeholder "nufmt"
 , nodePackages
@@ -187,6 +188,7 @@ in
     nil
     nixf-diagnose
     nixpkgs-fmt
+    nu-lint
     nushell
     nufmt
     opam

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -64,6 +64,7 @@
 , nixfmt-classic ? placeholder "nixfmt-classic"
 , nixfmt-rfc-style ? placeholder "nixfmt-rfc-style"
 , nixpkgs-fmt
+, nushell ? placeholder "nushell"
 , nufmt ? placeholder "nufmt"
 , nodePackages
 , ocamlPackages
@@ -186,6 +187,7 @@ in
     nil
     nixf-diagnose
     nixpkgs-fmt
+    nushell
     nufmt
     opam
     opentofu


### PR DESCRIPTION
### Summary
Adds hooks for Nushell script checking and linting:

1. **`nu-check`**: Validates and parses Nushell scripts using Nushell's built-in `nu-check --debug` command (with optional `settings.asModule` support).
2. **`nu-lint`**: Static analysis and linter for Nushell scripts using [`nu-lint`](https://codeberg.org/wvhulle/nu-lint) (with optional `settings.configPath` and `settings.fix` support).

Both hooks target `.nu` files using `files = "\\.nu$";`.